### PR TITLE
Rework the logging infrastructure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ endif
 #
 # Uncomment for debug compilation
 #
-# ccflags-m := -ggdb
-# ccflags-y := ${ccflags-m}
+#ccflags-m := -ggdb -DP_LKRG_DEBUG_BUILD -finstrument-functions
+#ccflags-y := ${ccflags-m}
+#p_lkrg-objs += src/modules/print_log/p_lkrg_debug_log.o
 
 obj-m += p_lkrg.o
 p_lkrg-objs += src/modules/ksyms/p_resolve_ksym.o \

--- a/src/modules/comm_channel/p_comm_channel.c
+++ b/src/modules/comm_channel/p_comm_channel.c
@@ -356,10 +356,6 @@ static int p_sysctl_kint_validate(struct ctl_table *p_table, int p_write,
       "PERIODICALLY + RANDOM EVENTS"
    };
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_kint_validate>\n");
-
    p_tmp = P_CTRL(p_kint_validate);
    p_lkrg_open_rw();
    if ( (p_ret = proc_dointvec_minmax(p_table, p_write, p_buffer, p_len, p_pos)) == 0 && p_write) {
@@ -382,10 +378,6 @@ static int p_sysctl_kint_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_kint_validate>\n");
-
    return p_ret;
 }
 
@@ -403,10 +395,6 @@ static int p_sysctl_kint_enforce(struct ctl_table *p_table, int p_write,
 #endif
       "PANIC"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_kint_enforce>\n");
 
    p_tmp = P_CTRL(p_kint_enforce);
    p_lkrg_open_rw();
@@ -429,10 +417,6 @@ static int p_sysctl_kint_enforce(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_kint_enforce>\n");
-
    return p_ret;
 }
 
@@ -447,10 +431,6 @@ static int p_sysctl_pint_validate(struct ctl_table *p_table, int p_write,
       "CURRENT + WAKING UP",
       "ALL TASKS"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_pint_validate>\n");
 
    p_tmp = P_CTRL(p_pint_validate);
    p_lkrg_open_rw();
@@ -468,10 +448,6 @@ static int p_sysctl_pint_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_pint_validate>\n");
-
    return p_ret;
 }
 
@@ -485,10 +461,6 @@ static int p_sysctl_pint_enforce(struct ctl_table *p_table, int p_write,
       "KILL TASK",
       "PANIC"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_pint_enforce>\n");
 
    p_tmp = P_CTRL(p_pint_enforce);
    p_lkrg_open_rw();
@@ -506,10 +478,6 @@ static int p_sysctl_pint_enforce(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_pint_enforce>\n");
-
    return p_ret;
 }
 
@@ -518,20 +486,12 @@ static int p_sysctl_interval(struct ctl_table *p_table, int p_write,
                               void __user *p_buffer, size_t *p_len, loff_t *p_pos) {
    int p_ret;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_interval>\n");
-
    p_lkrg_open_rw();
    if ( (p_ret = proc_dointvec_minmax(p_table, p_write, p_buffer, p_len, p_pos)) == 0 && p_write) {
       p_print_log(P_LKRG_CRIT, "[kINT] New interval => %d\n", P_CTRL(p_interval));
       p_offload_work(0); // run integrity check!
    }
    p_lkrg_close_rw();
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_interval>\n");
 
    return p_ret;
 }
@@ -541,10 +501,6 @@ static int p_sysctl_block_modules(struct ctl_table *p_table, int p_write,
 
    int p_ret;
    unsigned int p_tmp;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_block_modules>\n");
 
    p_tmp = P_CTRL(p_block_modules);
    p_lkrg_open_rw();
@@ -558,10 +514,6 @@ static int p_sysctl_block_modules(struct ctl_table *p_table, int p_write,
       }
    }
    p_lkrg_close_rw();
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_block_modules>\n");
 
    return p_ret;
 }
@@ -581,10 +533,6 @@ static int p_sysctl_log_level(struct ctl_table *p_table, int p_write,
 #endif
    };
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_log_level>\n");
-
    p_lkrg_open_rw();
    if ( (p_ret = proc_dointvec_minmax(p_table, p_write, p_buffer, p_len, p_pos)) == 0 && p_write) {
       p_print_log(P_LKRG_CRIT, "New log level => %d (%s)\n",
@@ -592,10 +540,6 @@ static int p_sysctl_log_level(struct ctl_table *p_table, int p_write,
                   p_log_level_string[P_CTRL(p_log_level]));
    }
    p_lkrg_close_rw();
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_log_level>\n");
 
    return p_ret;
 }
@@ -605,10 +549,6 @@ static int p_sysctl_trigger(struct ctl_table *p_table, int p_write,
                             void __user *p_buffer, size_t *p_len, loff_t *p_pos) {
 
    int p_ret;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_trigger>\n");
 
    p_lkrg_open_rw();
    if ( (p_ret = proc_dointvec_minmax(p_table, p_write, p_buffer, p_len, p_pos)) == 0 && p_write) {
@@ -620,10 +560,6 @@ static int p_sysctl_trigger(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_trigger>\n");
-
    return p_ret;
 }
 
@@ -633,10 +569,6 @@ static int p_sysctl_hide(struct ctl_table *p_table, int p_write,
 
    int p_ret;
    unsigned int p_tmp;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_hide>\n");
 
    p_tmp = P_CTRL(p_hide_lkrg);
    p_lkrg_open_rw();
@@ -651,10 +583,6 @@ static int p_sysctl_hide(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_hide>\n");
-
    return p_ret;
 }
 #endif
@@ -664,10 +592,6 @@ static int p_sysctl_heartbeat(struct ctl_table *p_table, int p_write,
 
    int p_ret;
    unsigned int p_tmp;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_heartbeat>\n");
 
    p_tmp = P_CTRL(p_heartbeat);
    p_lkrg_open_rw();
@@ -682,10 +606,6 @@ static int p_sysctl_heartbeat(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_heartbeat>\n");
-
    return p_ret;
 }
 
@@ -695,10 +615,6 @@ static int p_sysctl_smep_validate(struct ctl_table *p_table, int p_write,
 
    int p_ret;
    unsigned int p_tmp;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_smep_validate>\n");
 
    p_tmp = P_CTRL(p_smep_validate);
    p_lkrg_open_rw();
@@ -724,10 +640,6 @@ static int p_sysctl_smep_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_smep_validate>\n");
-
    return p_ret;
 }
 
@@ -741,10 +653,6 @@ static int p_sysctl_smep_enforce(struct ctl_table *p_table, int p_write,
       "LOG & RESTORE",
       "PANIC"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_smep_enforce>\n");
 
    p_tmp = P_CTRL(p_smep_enforce);
    p_lkrg_open_rw();
@@ -770,10 +678,6 @@ static int p_sysctl_smep_enforce(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_smep_enforce>\n");
-
    return p_ret;
 }
 
@@ -782,10 +686,6 @@ static int p_sysctl_smap_validate(struct ctl_table *p_table, int p_write,
 
    int p_ret;
    unsigned int p_tmp;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_smap_validate>\n");
 
    p_tmp = P_CTRL(p_smap_validate);
    p_lkrg_open_rw();
@@ -811,10 +711,6 @@ static int p_sysctl_smap_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_smap_validate>\n");
-
    return p_ret;
 }
 
@@ -828,10 +724,6 @@ static int p_sysctl_smap_enforce(struct ctl_table *p_table, int p_write,
       "LOG & RESTORE",
       "PANIC"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_smap_enforce>\n");
 
    p_tmp = P_CTRL(p_smap_enforce);
    p_lkrg_open_rw();
@@ -857,10 +749,6 @@ static int p_sysctl_smap_enforce(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_smap_enforce>\n");
-
    return p_ret;
 }
 #endif
@@ -875,10 +763,6 @@ static int p_sysctl_umh_validate(struct ctl_table *p_table, int p_write,
       "Allow specific paths",
       "Completely block usermodehelper"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_umh_validate>\n");
 
    p_tmp = P_CTRL(p_umh_validate);
    p_lkrg_open_rw();
@@ -896,10 +780,6 @@ static int p_sysctl_umh_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_umh_validate>\n");
-
    return p_ret;
 }
 
@@ -913,10 +793,6 @@ static int p_sysctl_umh_enforce(struct ctl_table *p_table, int p_write,
       "PREVENT EXECUTION",
       "PANIC"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_umh_enforce>\n");
 
    p_tmp = P_CTRL(p_umh_enforce);
    p_lkrg_open_rw();
@@ -934,10 +810,6 @@ static int p_sysctl_umh_enforce(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_umh_enforce>\n");
-
    return p_ret;
 }
 
@@ -947,10 +819,6 @@ static int p_sysctl_msr_validate(struct ctl_table *p_table, int p_write,
    int p_ret;
    int p_cpu;
    unsigned int p_tmp;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_msr_validate>\n");
 
    p_tmp = P_CTRL(p_msr_validate);
    p_lkrg_open_rw();
@@ -979,10 +847,6 @@ static int p_sysctl_msr_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_msr_validate>\n");
-
    return p_ret;
 }
 
@@ -996,10 +860,6 @@ static int p_sysctl_pcfi_validate(struct ctl_table *p_table, int p_write,
       "No stackwalk (weak)",
       "Fully enabled"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_pcfi_validate>\n");
 
    p_tmp = P_CTRL(p_pcfi_validate);
    p_lkrg_open_rw();
@@ -1017,10 +877,6 @@ static int p_sysctl_pcfi_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_pcfi_validate>\n");
-
    return p_ret;
 }
 
@@ -1034,10 +890,6 @@ static int p_sysctl_pcfi_enforce(struct ctl_table *p_table, int p_write,
       "KILL TASK",
       "PANIC"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_pcfi_enforce>\n");
 
    p_tmp = P_CTRL(p_pcfi_enforce);
    p_lkrg_open_rw();
@@ -1055,10 +907,6 @@ static int p_sysctl_pcfi_enforce(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_pcfi_enforce>\n");
-
    return p_ret;
 }
 
@@ -1075,10 +923,6 @@ static int p_sysctl_profile_validate(struct ctl_table *p_table, int p_write,
       "Heavy",
       "Paranoid"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_profile_validate>\n");
 
    p_tmp = P_CTRL(p_profile_validate);
    p_lkrg_open_rw();
@@ -1308,10 +1152,6 @@ static int p_sysctl_profile_validate(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_profile_validate>\n");
-
    return p_ret;
 }
 
@@ -1326,10 +1166,6 @@ static int p_sysctl_profile_enforce(struct ctl_table *p_table, int p_write,
       "Strict",
       "Paranoid"
    };
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_sysctl_profile_enforce>\n");
 
    p_tmp = P_CTRL(p_profile_enforce);
    p_lkrg_open_rw();
@@ -1463,49 +1299,22 @@ static int p_sysctl_profile_enforce(struct ctl_table *p_table, int p_write,
    }
    p_lkrg_close_rw();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_sysctl_profile_enforce>\n");
-
    return p_ret;
 }
 
 
 int p_register_comm_channel(void) {
 
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_register_comm_channel>\n");
-
    if ( (p_sysctl_handle = register_sysctl_table(p_lkrg_sysctl_base)) == NULL) {
       p_print_log(P_LKRG_ERR,
              "Communication channel error! Can't register 'sysctl' table :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_register_comm_channel_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
-
-p_register_comm_channel_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_register_comm_channel>\n");
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 void p_deregister_comm_channel(void) {
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_deregister_comm_channel>\n");
-
    unregister_sysctl_table(p_sysctl_handle);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_deregister_comm_channel>\n");
-
 }

--- a/src/modules/database/CPU.c
+++ b/src/modules/database/CPU.c
@@ -50,10 +50,6 @@
 
 void p_get_cpus(p_cpu_info *p_arg) {
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_get_cpus>\n");
-
    memset(p_arg,0x0,sizeof(p_cpu_info));
 
    p_arg->online_CPUs = num_online_cpus();
@@ -68,20 +64,11 @@ void p_get_cpus(p_cpu_info *p_arg) {
           "<p_get_cpus> online[%d] possible[%d] present[%d] active[%d] nr_cpu_ids[%d]\n",
           p_arg->online_CPUs,p_arg->possible_CPUs,p_arg->present_CPUs,p_arg->active_CPUs,
           p_arg->p_nr_cpu_ids);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_get_cpus>\n");
-
 }
 
 int p_cmp_cpus(p_cpu_info *p_arg1, p_cpu_info *p_arg2) {
 
    int p_flag = 0x0;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_cmp_cpus>\n");
 
    if (p_arg1->online_CPUs != p_arg2->online_CPUs) {
       p_print_log(P_LKRG_CRIT,
@@ -109,10 +96,6 @@ int p_cmp_cpus(p_cpu_info *p_arg1, p_cpu_info *p_arg2) {
       p_flag++;
    }
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_cmp_cpus>\n");
-
    return p_flag;
 }
 
@@ -125,11 +108,6 @@ int p_cmp_cpus(p_cpu_info *p_arg1, p_cpu_info *p_arg2) {
 int p_cpu_callback(struct notifier_block *p_block, unsigned long p_action, void *p_hcpu) {
 
    unsigned int p_cpu = (unsigned long)p_hcpu;
-
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_cpu_callback>\n");
 
 // TODO: lock db
 //       lock is done in the individual action function
@@ -152,10 +130,6 @@ int p_cpu_callback(struct notifier_block *p_block, unsigned long p_action, void 
 //       lock is done in the individual action function
 //       to reduce locking/starving time
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_cpu_callback>\n");
-
    return NOTIFY_OK;
 }
 #endif
@@ -164,11 +138,6 @@ int p_cpu_callback(struct notifier_block *p_block, unsigned long p_action, void 
 int p_cpu_online_action(unsigned int p_cpu) {
 
    int tmp_online_CPUs = p_db.p_cpu.online_CPUs;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Entering function <p_cpu_online_action>\n");
 
    p_text_section_lock();
    /* We are heavily consuming module list here - take 'module_mutex' */
@@ -241,22 +210,12 @@ int p_cpu_online_action(unsigned int p_cpu) {
    mutex_unlock(&module_mutex);
    p_text_section_unlock();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Leaving function <p_cpu_online_action>\n");
-
    return 0x0;
 }
 
 int p_cpu_dead_action(unsigned int p_cpu) {
 
    int tmp_online_CPUs = p_db.p_cpu.online_CPUs;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Entering function <p_cpu_dead_action>\n");
 
    p_text_section_lock();
    /* We are heavily consuming module list here - take 'module_mutex' */
@@ -336,11 +295,6 @@ int p_cpu_dead_action(unsigned int p_cpu) {
    /* Release the 'module_mutex' */
    mutex_unlock(&module_mutex);
    p_text_section_unlock();
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Leaving function <p_cpu_dead_action>\n");
 
    return 0x0;
 }

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -47,8 +47,6 @@ int p_arch_jump_label_transform_entry(struct kretprobe_instance *p_ri, struct pt
    struct module *p_module = NULL;
 
    p_debug_kprobe_log(
-          "Entering function <p_arch_jump_label_transform_entry>\n");
-   p_debug_kprobe_log(
           "p_arch_jump_label_transform_entry: comm[%s] Pid:%d\n",current->comm,current->pid);
 
    p_print_log(P_LKRG_INFO,
@@ -84,9 +82,6 @@ int p_arch_jump_label_transform_entry(struct kretprobe_instance *p_ri, struct pt
                   "[JUMP_LABEL] <Entry> I should never be here!\n");
    }
 
-   p_debug_kprobe_log(
-          "Leaving function <p_arch_jump_label_transform_entry>\n");
-
    /* A dump_stack() here will give a stack backtrace */
    return 0x0;
 }
@@ -96,10 +91,6 @@ int p_arch_jump_label_transform_ret(struct kretprobe_instance *ri, struct pt_reg
 
    unsigned int p_tmp,p_tmp2;
    unsigned char p_flag = 0x0;
-
-   p_debug_kprobe_log(
-          "Entering function <p_arch_jump_label_transform_ret>\n");
-
 
    switch (p_db.p_jump_label.p_state) {
 
@@ -188,8 +179,6 @@ int p_arch_jump_label_transform_ret(struct kretprobe_instance *ri, struct pt_reg
 
    p_db.p_jump_label.p_state = P_JUMP_LABEL_NONE;
 
-   p_debug_kprobe_log(
-          "Entering function <p_arch_jump_label_transform_ret>\n");
    return 0x0;
 }
 
@@ -198,38 +187,22 @@ int p_install_arch_jump_label_transform_hook(void) {
 
    int p_ret;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_install_arch_jump_label_transform_hook>\n");
-
    if ( (p_ret = register_kretprobe(&p_arch_jump_label_transform_kretprobe)) < 0) {
       p_print_log(P_LKRG_ERR, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]\n",
                   p_arch_jump_label_transform_kretprobe.kp.symbol_name,
                   p_ret);
-      goto p_install_arch_jump_label_transform_hook_out;
+      return p_ret;
    }
    p_print_log(P_LKRG_INFO, "Planted [kretprobe] <%s> at: 0x%lx\n",
                p_arch_jump_label_transform_kretprobe.kp.symbol_name,
                (unsigned long)p_arch_jump_label_transform_kretprobe.kp.addr);
    p_arch_jump_label_transform_kretprobe_state = 0x1;
 
-//   p_ret = 0x0; <- should be 0x0 anyway...
-
-p_install_arch_jump_label_transform_hook_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_install_arch_jump_label_transform_hook> (p_ret => %d)\n",p_ret);
-
    return p_ret;
 }
 
 
 void p_uninstall_arch_jump_label_transform_hook(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_uninstall_arch_jump_label_transform_hook>\n");
 
    if (!p_arch_jump_label_transform_kretprobe_state) {
       p_print_log(P_LKRG_INFO, "[kretprobe] <%s> at 0x%lx is NOT installed\n",
@@ -243,8 +216,4 @@ void p_uninstall_arch_jump_label_transform_hook(void) {
                   p_arch_jump_label_transform_kretprobe.nmissed);
       p_arch_jump_label_transform_kretprobe_state = 0x0;
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_uninstall_arch_jump_label_transform_hook>\n");
 }

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -54,8 +54,6 @@ int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p_ri, str
    p_text_poke_loc *p_tmp;
 
    p_debug_kprobe_log(
-          "Entering function <p_arch_jump_label_transform_apply_entry>\n");
-   p_debug_kprobe_log(
           "p_arch_jump_label_transform_apply_entry: comm[%s] Pid:%d\n",current->comm,current->pid);
 
    p_print_log(P_LKRG_INFO,
@@ -86,9 +84,6 @@ int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p_ri, str
       }
    }
 
-   p_debug_kprobe_log(
-          "Leaving function <p_arch_jump_label_transform_apply_entry>\n");
-
    /* A dump_stack() here will give a stack backtrace */
    return 0x0;
 }
@@ -103,9 +98,6 @@ int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri, struct 
    unsigned int p_text = 0x0;
    unsigned int p_mod = 0x0;
 //   DECLARE_BITMAP(p_mod_mask, p_db.p_module_list_nr);
-
-   p_debug_kprobe_log(
-          "Entering function <p_arch_jump_label_transform_apply_ret>\n");
 
    bitmap_zero(p_db.p_jump_label.p_mod_mask, p_db.p_module_list_nr);
 
@@ -217,9 +209,6 @@ int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri, struct 
 
    p_db.p_jump_label.p_state = P_JUMP_LABEL_NONE;
 
-   p_debug_kprobe_log(
-          "Entering function <p_arch_jump_label_transform_apply_ret>\n");
-
    return 0x0;
 }
 
@@ -227,10 +216,6 @@ int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri, struct 
 int p_install_arch_jump_label_transform_apply_hook(void) {
 
    int p_ret;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_install_arch_jump_label_transform_apply_hook>\n");
 
    P_SYM(p_tp_vec) = (struct text_poke_loc **)P_SYM(p_kallsyms_lookup_name)("tp_vec");
    P_SYM(p_tp_vec_nr) = (int *)P_SYM(p_kallsyms_lookup_name)("tp_vec_nr");
@@ -245,38 +230,25 @@ int p_install_arch_jump_label_transform_apply_hook(void) {
       p_print_log(P_LKRG_ERR,
              "<p_install_arch_jump_label_transform_apply_hook> "
              "Can't find 'tp_vec' / 'tp_vec_nr' variable :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_install_arch_jump_label_transform_apply_hook_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    if ( (p_ret = register_kretprobe(&p_arch_jump_label_transform_apply_kretprobe)) < 0) {
       p_print_log(P_LKRG_ERR, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]\n",
                   p_arch_jump_label_transform_apply_kretprobe.kp.symbol_name,
                   p_ret);
-      goto p_install_arch_jump_label_transform_apply_hook_out;
+      return p_ret;
    }
    p_print_log(P_LKRG_INFO, "Planted [kretprobe] <%s> at: 0x%lx\n",
                p_arch_jump_label_transform_apply_kretprobe.kp.symbol_name,
                (unsigned long)p_arch_jump_label_transform_apply_kretprobe.kp.addr);
    p_arch_jump_label_transform_apply_kretprobe_state = 0x1;
 
-//   p_ret = 0x0; <- should be 0x0 anyway...
-
-p_install_arch_jump_label_transform_apply_hook_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_install_arch_jump_label_transform_apply_hook> (p_ret => %d)\n",p_ret);
-
    return p_ret;
 }
 
 
 void p_uninstall_arch_jump_label_transform_apply_hook(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_uninstall_arch_jump_label_transform_apply_hook>\n");
 
    if (!p_arch_jump_label_transform_apply_kretprobe_state) {
       p_print_log(P_LKRG_INFO, "[kretprobe] <%s> at 0x%lx is NOT installed\n",
@@ -290,10 +262,6 @@ void p_uninstall_arch_jump_label_transform_apply_hook(void) {
                   p_arch_jump_label_transform_apply_kretprobe.nmissed);
       p_arch_jump_label_transform_apply_kretprobe_state = 0x0;
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_uninstall_arch_jump_label_transform_apply_hook>\n");
 }
 
 #endif

--- a/src/modules/database/arch/arm/p_arm_metadata.c
+++ b/src/modules/database/arch/arm/p_arm_metadata.c
@@ -38,10 +38,6 @@ void p_dump_arm_metadata(void *_p_arg) {
    p_CPU_metadata_hash_mem *p_arg = _p_arg;
    int p_curr_cpu = 0xFFFFFFFF;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_dump_arm_metadata>\n");
-
    /*
     * Get ID and lock - no preemtion.
     */
@@ -59,10 +55,6 @@ void p_dump_arm_metadata(void *_p_arg) {
     */
     p_arg[p_curr_cpu].p_cpu_id = p_curr_cpu;
     p_arg[p_curr_cpu].p_cpu_online = P_CPU_ONLINE;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_dump_arm_metadata>\n");
 }
 
 #endif

--- a/src/modules/database/arch/arm64/p_arm64_metadata.c
+++ b/src/modules/database/arch/arm64/p_arm64_metadata.c
@@ -38,10 +38,6 @@ void p_dump_arm64_metadata(void *_p_arg) {
    p_CPU_metadata_hash_mem *p_arg = _p_arg;
    int p_curr_cpu = 0xFFFFFFFF;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_dump_arm64_metadata>\n");
-
    /*
     * Get ID and lock - no preemtion.
     */
@@ -59,10 +55,6 @@ void p_dump_arm64_metadata(void *_p_arg) {
     */
     p_arg[p_curr_cpu].p_cpu_id = p_curr_cpu;
     p_arg[p_curr_cpu].p_cpu_online = P_CPU_ONLINE;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_dump_arm64_metadata>\n");
 }
 
 #endif

--- a/src/modules/database/arch/p_arch_metadata.c
+++ b/src/modules/database/arch/p_arch_metadata.c
@@ -40,19 +40,12 @@ void p_dump_CPU_metadata(void *_p_arg) {
 
 int p_register_arch_metadata(void) {
 
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_register_arch_metadata>\n");
-
    P_SYM(p_core_kernel_text) = (int (*)(unsigned long))P_SYM(p_kallsyms_lookup_name)("core_kernel_text");
 
    if (!P_SYM(p_core_kernel_text)) {
       p_print_log(P_LKRG_ERR,
              "[ED] ERROR: Can't find 'core_kernel_text' function :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_register_arch_metadata_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
 #ifdef P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
@@ -78,8 +71,7 @@ int p_register_arch_metadata(void) {
    if (p_install_arch_jump_label_transform_hook()) {
       p_print_log(P_LKRG_ERR,
              "ERROR: Can't hook arch_jump_label_transform function :(\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_register_arch_metadata_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
 #ifdef P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_APPLY_H
@@ -89,28 +81,15 @@ int p_register_arch_metadata(void) {
    if (p_install_arch_jump_label_transform_apply_hook()) {
       p_print_log(P_LKRG_ERR,
              "ERROR: Can't hook arch_jump_label_transform_apply function :(\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_register_arch_metadata_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 #endif
 
-p_register_arch_metadata_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_register_arch_metadata> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 
 int p_unregister_arch_metadata(void) {
-
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_register_arch_metadata>\n");
 
 #ifdef P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
    p_uninstall_switch_idt_hook();
@@ -124,9 +103,5 @@ int p_unregister_arch_metadata(void) {
    p_uninstall_arch_jump_label_transform_apply_hook();
 #endif
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_register_arch_metadata> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }

--- a/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
+++ b/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
@@ -39,13 +39,7 @@ static struct kretprobe p_switch_idt_kretprobe = {
 
 int p_switch_idt_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-   p_debug_kprobe_log(
-          "Entering function <p_switch_idt_entry>\n");
-
    spin_lock(&p_db_lock);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_switch_idt_entry>\n");
 
    /* A dump_stack() here will give a stack backtrace */
    return 0x0;
@@ -53,10 +47,6 @@ int p_switch_idt_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
 
 
 int p_switch_idt_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
-
-   p_debug_kprobe_log(
-          "Entering function <p_switch_idt_ret>\n");
-
 
 /*
    on_each_cpu(p_dump_CPU_metadata,p_tmp_cpus,true);
@@ -67,8 +57,6 @@ int p_switch_idt_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    spin_unlock(&p_db_lock);
 
-   p_debug_kprobe_log(
-          "Leaving function <p_switch_idt_ret>\n");
    return 0x0;
 }
 
@@ -77,38 +65,22 @@ int p_install_switch_idt_hook(void) {
 
    int p_ret;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_install_switch_idt_hook>\n");
-
    if ( (p_ret = register_kretprobe(&p_switch_idt_kretprobe)) < 0) {
       p_print_log(P_LKRG_ERR, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]\n",
                   p_switch_idt_kretprobe.kp.symbol_name,
                   p_ret);
-      goto p_install_switch_idt_hook_out;
+      return p_ret;
    }
    p_print_log(P_LKRG_INFO, "Planted [kretprobe] <%s> at: 0x%lx\n",
                p_switch_idt_kretprobe.kp.symbol_name,
                (unsigned long)p_switch_idt_kretprobe.kp.addr);
    p_switch_idt_kretprobe_state = 0x1;
 
-//   p_ret = 0x0; <- should be 0x0 anyway...
-
-p_install_switch_idt_hook_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_install_switch_idt_hook> (p_ret => %d)\n",p_ret);
-
    return p_ret;
 }
 
 
 void p_uninstall_switch_idt_hook(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_uninstall_switch_idt_hook>\n");
 
    if (!p_switch_idt_kretprobe_state) {
       p_print_log(P_LKRG_INFO, "[kretprobe] <%s> at 0x%lx is NOT installed\n",
@@ -122,10 +94,6 @@ void p_uninstall_switch_idt_hook(void) {
                   p_switch_idt_kretprobe.nmissed);
       p_switch_idt_kretprobe_state = 0x0;
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_uninstall_switch_idt_hook>\n");
 }
 
 #endif

--- a/src/modules/database/arch/x86/p_x86_metadata.c
+++ b/src/modules/database/arch/x86/p_x86_metadata.c
@@ -37,10 +37,6 @@ u64 p_read_msr(/*int p_cpu, */u32 p_arg) {
     u64 p_val;
 //    int p_err;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_read_msr>\n");
-
    p_low = p_high = p_val = 0x0;
 
     __asm__("rdmsr": P_MSR_ASM_READ(p_val,p_low,p_high)
@@ -63,10 +59,6 @@ u64 p_read_msr(/*int p_cpu, */u32 p_arg) {
    p_debug_log(P_LKRG_DBG,
           "<p_read_msr[%d]> MSR arg[0x%x] value[%llx]\n",smp_processor_id(),p_arg,p_val);
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_read_msr>\n");
-
     return p_val;
 }
 
@@ -87,10 +79,6 @@ void p_dump_x86_metadata(void *_p_arg) {
 #endif
 
    int p_curr_cpu = 0xFFFFFFFF;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_dump_x86_metadata>\n");
 
    /*
     * Get ID and lock - no preemtion.
@@ -386,11 +374,6 @@ void p_dump_x86_metadata(void *_p_arg) {
     * Unlock preemtion.
     */
 //   put_cpu();
-
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_dump_x86_metadata>\n");
 
 }
 

--- a/src/modules/database/p_database.c
+++ b/src/modules/database/p_database.c
@@ -22,18 +22,12 @@ p_hash_database p_db;
 int hash_from_ex_table(void) {
 
    unsigned long p_tmp = 0x0;
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <hash_from_ex_table>\n");
 
    p_db.kernel_ex_table.p_addr = (unsigned long *)P_SYM(p_kallsyms_lookup_name)("__start___ex_table");
    p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("__stop___ex_table");
 
    if (!p_db.kernel_ex_table.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_ex_table.p_addr) {
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto hash_from_ex_table_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    p_db.kernel_ex_table.p_size = (unsigned long)(p_tmp - (unsigned long)p_db.kernel_ex_table.p_addr);
@@ -46,30 +40,18 @@ int hash_from_ex_table(void) {
                                                                    (long)p_db.kernel_ex_table.p_addr,
                                                                    (long)p_db.kernel_ex_table.p_size);
 
-hash_from_ex_table_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <hash_from_ex_table> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 int hash_from_kernel_stext(void) {
 
    unsigned long p_tmp = 0x0;
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <hash_from_kernel_stext>\n");
 
    p_db.kernel_stext.p_addr = (unsigned long *)P_SYM(p_kallsyms_lookup_name)("_stext");
    p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("_etext");
 
    if (!p_db.kernel_stext.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_stext.p_addr) {
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto hash_from_kernel_stext_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    p_db.kernel_stext.p_size = (unsigned long)(p_tmp - (unsigned long)p_db.kernel_stext.p_addr);
@@ -97,31 +79,18 @@ int hash_from_kernel_stext(void) {
           "hash [0x%llx] _stext start [0x%lx] size [0x%lx]\n",p_db.kernel_stext.p_hash,
                                                               (long)p_db.kernel_stext.p_addr,
                                                               (long)p_db.kernel_stext.p_size);
-
-hash_from_kernel_stext_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <hash_from_kernel_stext> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 int hash_from_kernel_rodata(void) {
 
    unsigned long p_tmp = 0x0;
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <hash_from_kernel_rodata>\n");
 
    p_db.kernel_rodata.p_addr = (unsigned long *)P_SYM(p_kallsyms_lookup_name)("__start_rodata");
    p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("__end_rodata");
 
    if (!p_db.kernel_rodata.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_rodata.p_addr) {
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto hash_from_kernel_rodata_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    p_db.kernel_rodata.p_size = (unsigned long)(p_tmp - (unsigned long)p_db.kernel_rodata.p_addr);
@@ -141,14 +110,7 @@ int hash_from_kernel_rodata(void) {
           "hash [0x%llx] _rodata start [0x%lx] size [0x%lx]\n",p_db.kernel_rodata.p_hash,
                                                                (long)p_db.kernel_rodata.p_addr,
                                                                (long)p_db.kernel_rodata.p_size);
-
-hash_from_kernel_rodata_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <hash_from_kernel_rodata> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 int hash_from_iommu_table(void) {
@@ -156,11 +118,6 @@ int hash_from_iommu_table(void) {
 #ifdef CONFIG_X86
    unsigned long p_tmp = 0x0;
 #endif
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <hash_from_iommu_table>\n");
 
 #ifdef CONFIG_X86
 
@@ -168,8 +125,7 @@ int hash_from_iommu_table(void) {
    p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("__iommu_table_end");
 
    if (!p_db.kernel_iommu_table.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_iommu_table.p_addr) {
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto hash_from_iommu_table_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    p_db.kernel_iommu_table.p_size = (unsigned long)(p_tmp - (unsigned long)p_db.kernel_iommu_table.p_addr);
@@ -188,8 +144,6 @@ int hash_from_iommu_table(void) {
                                                                      (long)p_db.kernel_iommu_table.p_addr,
                                                                      (long)p_db.kernel_iommu_table.p_size);
 
-hash_from_iommu_table_out:
-
 #else
 
 // Static value - might change in normal system...
@@ -197,21 +151,13 @@ hash_from_iommu_table_out:
 
 #endif
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <hash_from_iommu_table> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 uint64_t hash_from_CPU_data(p_CPU_metadata_hash_mem *p_arg) {
 
    int p_tmp = 0x0;
    uint64_t p_hash = 0x0;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <hash_from_CPU_data>\n");
 
    for_each_present_cpu(p_tmp) {
       if (p_arg[p_tmp].p_cpu_online == P_CPU_ONLINE) {
@@ -237,10 +183,6 @@ uint64_t hash_from_CPU_data(p_CPU_metadata_hash_mem *p_arg) {
       }
    }
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <hash_from_CPU_data>\n");
-
    return p_hash;
 }
 
@@ -248,19 +190,13 @@ int p_create_database(void) {
 
    int p_tmp;
 //   int p_tmp_cpu;
-   int p_ret;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_create_database>\n");
 
    memset(&p_db,0x0,sizeof(p_hash_database));
 
    if ( (P_SYM(p_text_mutex) = (struct mutex *)P_SYM(p_kallsyms_lookup_name)("text_mutex")) == NULL) {
       p_print_log(P_LKRG_ERR,
              "CREATING DATABASE: error! Can't find 'text_mutex' variable :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_create_database_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    /*
@@ -286,8 +222,7 @@ int p_create_database(void) {
        */
       p_print_log(P_LKRG_CRIT,
              "CREATING DATABASE: kzalloc() error! Can't allocate memory ;[\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_create_database_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 // STRONG_DEBUG
      else {
@@ -344,8 +279,7 @@ int p_create_database(void) {
    if (p_register_arch_metadata() != P_LKRG_SUCCESS) {
       p_print_log(P_LKRG_ERR,
              "CREATING DATABASE: error! Can't register CPU architecture specific metadata :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_create_database_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
 
@@ -401,15 +335,13 @@ int p_create_database(void) {
    if (p_install_arch_jump_label_transform_hook()) {
       p_print_log(P_LKRG_ERR,
              "ERROR: Can't hook arch_jump_label_transform function :(\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_create_database_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    if (p_install_arch_jump_label_transform_static_hook()) {
       p_print_log(P_LKRG_ERR,
              "ERROR: Can't hook arch_jump_label_transform_static function :(\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_create_database_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 */
 
@@ -423,23 +355,11 @@ int p_create_database(void) {
    if (hash_from_kernel_stext() != P_LKRG_SUCCESS) {
       p_print_log(P_LKRG_CRIT,
          "CREATING DATABASE ERROR: HASH FROM _STEXT!\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
       p_text_section_unlock();
-      goto p_create_database_out;
-   } else {
-      p_ret = P_LKRG_SUCCESS;
+      return P_LKRG_GENERAL_ERROR;
    }
    p_text_section_unlock();
 #endif
 
-
-   p_ret = P_LKRG_SUCCESS;
-
-p_create_database_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_create_database> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -411,55 +411,27 @@ static void p_ed_wq_valid_cache_zero(void *p_arg) {
 
    struct work_struct *p_struct = p_arg;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_wq_valid_cache_zero>\n");
-
    memset(p_struct, 0x0, sizeof(struct work_struct));
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_wq_valid_cache_zero>\n");
-
 }
 
 int p_ed_wq_valid_cache_init(void) {
 
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_wq_valid_cache_init>\n");
-
    if ( (p_ed_wq_valid_cache = kmem_cache_create("p_ed_wq_valid_cache", sizeof(struct work_struct),
                                                  0x0, SLAB_HWCACHE_ALIGN, p_ed_wq_valid_cache_zero)) == NULL) {
       p_print_log(P_LKRG_ERR, "kmem_cache_create() for exploit detection validation error! :(\n");
-      p_ret = -ENOMEM;
+      return -ENOMEM;
    }
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_wq_valid_cache_init> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
-void p_ed_wq_valid_cache_delete(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_wq_valid_cache_delete>\n");
+static void p_ed_wq_valid_cache_delete(void) {
 
    flush_workqueue(system_unbound_wq);
    if (p_ed_wq_valid_cache) {
       kmem_cache_destroy(p_ed_wq_valid_cache);
       p_ed_wq_valid_cache = NULL;
    }
-
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_wq_valid_cache_delete>\n");
 }
 
 void p_dump_creds(struct p_cred *p_where, const struct cred *p_from) {
@@ -675,19 +647,13 @@ int p_print_task_f(void *p_arg) {
 int p_dump_task_f(void *p_arg) {
 
    struct task_struct *p_task = (struct task_struct *)p_arg;
-   int p_ret = P_LKRG_SUCCESS;
    struct p_ed_process *p_tmp;
    struct rb_root *p_root;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_dump_task_f>\n");
 
    if ( (p_tmp = p_alloc_ed_pids()) == NULL) {
       p_print_log(P_LKRG_ERR,
              "p_alloc_ed_pids() returned NULL for pid %d :(\n",p_task->pid);
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_dump_task_f_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    p_update_ed_process(p_tmp, p_task, 1);
@@ -701,49 +667,30 @@ int p_dump_task_f(void *p_arg) {
       p_print_log(P_LKRG_INFO,
                    "pid => %d is already inserted!\n",p_tmp->p_ed_task.p_pid);
       p_free_ed_pids(p_tmp);
-      p_ret = 0x1;
-      goto p_dump_task_f_out;
+      return 0x1;
    } else {
       p_print_log(P_LKRG_INFO,
                    "Inserting pid => %d\n", p_tmp->p_ed_task.p_pid);
    }
 
-p_dump_task_f_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_dump_task_f> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 int p_remove_task_pid_f(pid_t p_arg) {
 
-   int p_ret = P_LKRG_SUCCESS;
    struct p_ed_process *p_tmp;
    struct rb_root *p_root;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_remove_task_pid_f>\n");
 
    p_root = p_rb_hash_tree_lookup(p_arg);
    if ( (p_tmp = p_rb_find_ed_pid(p_root, p_arg)) == NULL) {
       // This process is not on the list!
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_remove_task_pid_f_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    p_rb_del_ed_pid(p_root, p_tmp);
    p_print_log(P_LKRG_INFO, "Removing ED pid => %d\n", p_arg);
 
-p_remove_task_pid_f_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_remove_task_pid_f> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
@@ -752,10 +699,6 @@ static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
    unsigned int p_err = 0x0;
    struct task_struct *p_ptmp, *p_tmp;
    unsigned long p_flags;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_iterate_processes>\n");
 
    p_tasks_read_lock(&p_flags);
    rcu_read_lock();
@@ -796,10 +739,6 @@ static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
 #endif
    rcu_read_unlock();
    p_tasks_read_unlock(&p_flags);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_iterate_processes>\n");
 
    return p_err;
 }
@@ -1244,10 +1183,6 @@ int p_validate_task_f(void *p_arg) {
    struct p_ed_process *p_tmp;
    struct task_struct *p_task = (struct task_struct *)p_arg;
 
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Entering function <p_validate_task_f>\n");
-
    rcu_read_lock();
    get_task_struct(p_task);
 
@@ -1271,10 +1206,6 @@ p_validate_task_out:
 
    put_task_struct(p_task);
    rcu_read_unlock();
-
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Leaving function <p_validate_task_f> (p_ret => %d)\n",p_ret);
 
    return p_ret;
 }
@@ -1311,13 +1242,8 @@ p_validate_task_from_running_out:
 }
 
 #ifdef CONFIG_SECURITY_SELINUX
-void p_validate_selinux(void) {
-
+static void p_validate_selinux(void) {
    unsigned long p_flags;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_validate_selinux>\n");
 
    do {
       p_lkrg_selinux_lock_lock(&p_ed_guard_globals.p_selinux_lock, &p_flags);
@@ -1400,18 +1326,10 @@ void p_validate_selinux(void) {
  #endif
 #endif
    p_lkrg_selinux_lock_unlock(&p_ed_guard_globals.p_selinux_lock, &p_flags);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_validate_selinux>\n");
 }
 #endif
 
-void p_ed_wq_valid_work(struct work_struct *p_work) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_wq_valid_work>\n");
+static void p_ed_wq_valid_work(struct work_struct *p_work) {
 
 #ifdef CONFIG_SECURITY_SELINUX
    // SELinux
@@ -1422,19 +1340,11 @@ void p_ed_wq_valid_work(struct work_struct *p_work) {
    if (p_work) {
       p_ed_free_valid(p_work);
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_wq_valid_work>\n");
 }
 
-void p_ed_validate_globals(void) {
+static void p_ed_validate_globals(void) {
 
    struct work_struct *p_worker;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_validate_globals>\n");
 
    if (P_CTRL(p_kint_validate)) {
 
@@ -1448,10 +1358,6 @@ void p_ed_validate_globals(void) {
       queue_work(system_unbound_wq, p_worker);
 
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_validate_globals>\n");
 }
 
 void p_ed_validate_current(void) {
@@ -1510,10 +1416,6 @@ void p_ed_enforce_validation(void) {
 
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_enforce_validation>\n");
-
    p_ed_pcfi_cpu(0);
 
    switch (P_CTRL(p_pint_validate)) {
@@ -1537,19 +1439,11 @@ void p_ed_enforce_validation(void) {
 
    /* Validate critical globals */
 //   p_ed_validate_globals();
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_enforce_validation>\n");
 }
 
 unsigned int p_ed_enforce_validation_paranoid(void) {
 
    unsigned int p_ret = 0x0;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_enforce_validation_paranoid>\n");
 
    p_ed_pcfi_cpu(0);
 
@@ -1564,10 +1458,6 @@ p_ed_enforce_validation_paranoid_globals:
    /* Validate critical globals */
    p_ed_validate_globals();
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_enforce_validation_paranoid>\n");
-
    return p_ret;
 }
 
@@ -1575,25 +1465,12 @@ static void p_ed_pcfi_cache_zero(void *p_arg) {
 
    unsigned long *p_page = p_arg;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_pcfi_cache_zero>\n");
-
    memset(p_page, 0x0, P_PCFI_STACK_BUF);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_pcfi_cache_zero>\n");
-
 }
 
-int p_ed_pcfi_cache_init(void) {
+static int p_ed_pcfi_cache_init(void) {
 
    int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_pcfi_cache_init>\n");
 
    if ( (p_ed_pcfi_cache = kmem_cache_create("p_ed_pcfi_cache", P_PCFI_STACK_BUF,
                                             0x0, SLAB_HWCACHE_ALIGN, p_ed_pcfi_cache_zero)) == NULL) {
@@ -1601,27 +1478,15 @@ int p_ed_pcfi_cache_init(void) {
       p_ret = -ENOMEM;
    }
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_pcfi_cache_init> (p_ret => %d)\n",p_ret);
-
    return p_ret;
 }
 
-void p_ed_pcfi_cache_delete(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_pcfi_cache_delete>\n");
+static void p_ed_pcfi_cache_delete(void) {
 
    if (p_ed_pcfi_cache) {
       kmem_cache_destroy(p_ed_pcfi_cache);
       p_ed_pcfi_cache = NULL;
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_pcfi_cache_delete>\n");
 }
 
 static inline int p_is_obj_on_stack(struct task_struct *p_task, const void *p_addr) {
@@ -1653,10 +1518,6 @@ int p_ed_enforce_pcfi(struct task_struct *p_task, struct p_ed_process *p_orig, s
    unsigned int p_offset = 1;
    char p_sym1[KSYM_SYMBOL_LEN];
    char p_not_valid = 0x0;
-
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Entering function <p_ed_enforce_pcfi>\n");
 
    if (p_ed_pcfi_validate_sp(p_task,p_orig,p_regs_get_sp(p_regs))) {
       p_print_log(P_LKRG_CRIT,
@@ -1890,25 +1751,16 @@ p_ed_enforce_pcfi_unlock_out:
 
 p_ed_enforce_pcfi_out:
 
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Leaving function <p_ed_enforce_pcfi> (return => %d)\n",p_not_valid);
-
    return p_not_valid;
 }
 
 int p_ed_pcfi_validate_sp(struct task_struct *p_task, struct p_ed_process *p_orig, unsigned long p_sp) {
 
    unsigned long p_stack = (p_orig) ? (unsigned long) p_orig->p_ed_task.p_stack : 0x0;
-   char p_not_valid = 0x0;
    register unsigned long p_stack_offset;
 
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Entering function <p_ed_pcfi_validate_sp>\n");
-
    if (!P_CTRL(p_pcfi_validate)) {
-      goto p_ed_pcfi_validate_sp_out;
+      return 0x0;
    }
 
    /*
@@ -1922,72 +1774,67 @@ int p_ed_pcfi_validate_sp(struct task_struct *p_task, struct p_ed_process *p_ori
       p_print_log(P_LKRG_INFO, "[base:0x%lx c:0x%lx]\n",
              p_stack,
              p_sp);
-      p_not_valid = 1;
+      return 0x1;
    }
 
-   if (p_stack) {
-
-      if (p_task != p_orig->p_ed_task.p_task) {
-         p_print_log(P_LKRG_WARN,
-                "<Exploit Detection> [pCFI - SP] Potential kretprobe glitch detected for process[%s] vs orig[%s]\n",
-                p_task->comm,
-                p_orig->p_ed_task.p_comm);
-         p_print_log(P_LKRG_INFO,
-                "process[0x%lx | %d | %s] vs orig[0x%lx | %d | %s]\n",
-                (unsigned long)p_task,
-                task_pid_nr(p_task),
-                p_task->comm,
-                (unsigned long)p_orig->p_ed_task.p_task,
-                p_orig->p_ed_task.p_pid,
-                p_orig->p_ed_task.p_comm);
-         goto p_ed_pcfi_validate_sp_out;
-      }
-
-      /*
-       * Validate stack base
-       */
-      if (unlikely((p_sp & ~(THREAD_SIZE - 1)) != (p_stack & ~(THREAD_SIZE - 1)))) {
-         p_print_log(P_LKRG_CRIT,
-                "<Exploit Detection> process [%s | %d] has invalid base for stack pointer!\n",
-                p_task->comm,
-                task_pid_nr(p_task));
-         p_print_log(P_LKRG_INFO, "[base:0x%lx c:0x%lx]\n",
-                p_stack,
-                p_sp);
-         p_not_valid = 1;
-      }
-
-      /*
-       * Validate if stack is coming from the valid range (CONFIG_VMAP_STACK)
-       */
-
-      // TODO
-
-      /*
-       * Validate current size of the stack.
-       */
-
-      p_stack_offset = p_sp - p_stack;
-      if (unlikely(p_stack_offset >= THREAD_SIZE)) {
-         p_print_log(P_LKRG_CRIT,
-                "<Exploit Detection> process [%s | %d] has invalid stack pointer (stack size mismatch)!\n",
-                p_task->comm,
-                task_pid_nr(p_task));
-         p_print_log(P_LKRG_INFO, "[base:0x%lx c:0x%lx diff:0x%lx]\n",
-                p_stack,
-                p_sp,
-                p_stack_offset);
-         p_not_valid = 1;
-      }
+   if (!p_stack) {
+      return 0x00;
    }
 
-p_ed_pcfi_validate_sp_out:
+   if (p_task != p_orig->p_ed_task.p_task) {
+      p_print_log(P_LKRG_WARN,
+             "<Exploit Detection> [pCFI - SP] Potential kretprobe glitch detected for process[%s] vs orig[%s]\n",
+             p_task->comm,
+             p_orig->p_ed_task.p_comm);
+      p_print_log(P_LKRG_INFO,
+             "process[0x%lx | %d | %s] vs orig[0x%lx | %d | %s]\n",
+             (unsigned long)p_task,
+             task_pid_nr(p_task),
+             p_task->comm,
+             (unsigned long)p_orig->p_ed_task.p_task,
+             p_orig->p_ed_task.p_pid,
+             p_orig->p_ed_task.p_comm);
+      return 0x1;
+   }
 
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Leaving function <p_ed_pcfi_validate_sp> (return => %d)\n",p_not_valid);
+   /*
+    * Validate stack base
+    */
+   if (unlikely((p_sp & ~(THREAD_SIZE - 1)) != (p_stack & ~(THREAD_SIZE - 1)))) {
+      p_print_log(P_LKRG_CRIT,
+             "<Exploit Detection> process [%s | %d] has invalid base for stack pointer!\n",
+             p_task->comm,
+             task_pid_nr(p_task));
+      p_print_log(P_LKRG_INFO, "[base:0x%lx c:0x%lx]\n",
+             p_stack,
+             p_sp);
+      return 0x1;
+   }
 
-   return p_not_valid;
+   /*
+    * Validate if stack is coming from the valid range (CONFIG_VMAP_STACK)
+    */
+
+   // TODO
+
+   /*
+    * Validate current size of the stack.
+    */
+
+   p_stack_offset = p_sp - p_stack;
+   if (unlikely(p_stack_offset >= THREAD_SIZE)) {
+      p_print_log(P_LKRG_CRIT,
+             "<Exploit Detection> process [%s | %d] has invalid stack pointer (stack size mismatch)!\n",
+             p_task->comm,
+             task_pid_nr(p_task));
+      p_print_log(P_LKRG_INFO, "[base:0x%lx c:0x%lx diff:0x%lx]\n",
+             p_stack,
+             p_sp,
+             p_stack_offset);
+      return 0x1;
+   }
+
+   return 0x0;
 }
 
 
@@ -1995,11 +1842,6 @@ int p_exploit_detection_init(void) {
 
    int p_ret;
    const struct p_functions_hooks *p_fh_it;
-
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_exploit_detection_init>\n");
 
    p_usermodehelper_init();
 
@@ -2133,7 +1975,6 @@ int p_exploit_detection_init(void) {
              p_print_log(P_LKRG_WARN, "%s\n", p_fh_it->p_error_message);
              continue;
          }
-
          p_print_log(P_LKRG_ERR,
                 "ERROR: Can't hook %s :(\n", p_fh_it->name);
          p_ret = P_LKRG_GENERAL_ERROR;
@@ -2144,10 +1985,6 @@ int p_exploit_detection_init(void) {
 
 p_exploit_detection_init_out:
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_exploit_detection_init> (p_ret => %d)\n",p_ret);
-
    return p_ret;
 }
 
@@ -2155,10 +1992,6 @@ p_exploit_detection_init_out:
 void p_exploit_detection_exit(void) {
 
    const struct p_functions_hooks *p_fh_it;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_exploit_detection_exit>\n");
 
    for (p_fh_it = p_functions_hooks_array; p_fh_it->name != NULL; p_fh_it++) {
       p_fh_it->uninstall();
@@ -2174,8 +2007,4 @@ void p_exploit_detection_exit(void) {
    p_delete_rb_ed_pids();
 
    p_print_log(P_LKRG_INFO, "kmem_cache \"p_ed_pids\" destroyed!\n");
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_exploit_detection_exit>\n");
 }

--- a/src/modules/exploit_detection/p_rb_ed_trees/p_rb_ed_pids/p_rb_ed_pids_tree.c
+++ b/src/modules/exploit_detection/p_rb_ed_trees/p_rb_ed_pids/p_rb_ed_pids_tree.c
@@ -25,13 +25,6 @@ struct p_ed_process *p_rb_find_ed_pid(struct rb_root *p_root, pid_t p_arg) {
 
    struct rb_node *p_node = p_root->rb_node;
    struct p_ed_process *p_struct = NULL;
-   struct p_ed_process *p_ret = NULL;
-
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Entering function <p_rb_find_ed_pid>\n");
-
-//   spin_lock_irqsave(&p_rb_ed_pids_lock, p_flags);
 
    while(p_node) {
       p_struct = rb_entry(p_node, struct p_ed_process, p_rb);
@@ -41,20 +34,11 @@ struct p_ed_process *p_rb_find_ed_pid(struct rb_root *p_root, pid_t p_arg) {
       } else if (p_arg > p_struct->p_ed_task.p_pid) {
          p_node = p_node->rb_right;
       } else {
-         p_ret = p_struct;
-         goto p_rb_find_ed_pid_out;
+         return p_struct;
       }
    }
 
-p_rb_find_ed_pid_out:
-
-// STRONG_DEBUG - can be way too noisy
-//   p_debug_log(P_LKRG_STRONG_DBG,
-//          "Leaving function <p_rb_find_ed_pid> (p_ret => 0x%lx)\n",(unsigned long)p_ret);
-
-//   spin_unlock_irqrestore(&p_rb_ed_pids_lock, p_flags);
-
-   return p_ret;
+   return NULL;
 }
 
 
@@ -63,11 +47,6 @@ struct p_ed_process *p_rb_add_ed_pid(struct rb_root *p_root, pid_t p_arg, struct
    struct rb_node **p_node = &p_root->rb_node;
    struct rb_node *p_parent = NULL;
    struct p_ed_process *p_struct;
-   struct p_ed_process *p_ret = NULL;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_rb_add_ed_pid>\n");
 
    while(*p_node) {
       p_parent = *p_node;
@@ -78,62 +57,34 @@ struct p_ed_process *p_rb_add_ed_pid(struct rb_root *p_root, pid_t p_arg, struct
       } else if (p_arg > p_struct->p_ed_task.p_pid) {
          p_node = &(*p_node)->rb_right;
       } else {
-         p_ret = p_struct;
-         goto p_rb_add_ed_pid_out;
+         return p_struct;
       }
 
    }
    rb_link_node(&p_source->p_rb, p_parent, p_node);   // Insert this new node as a red leaf
    rb_insert_color(&p_source->p_rb, p_root);          // Rebalance the tree, finish inserting
 
-p_rb_add_ed_pid_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_rb_add_ed_pid> (p_ret => 0x%lx)\n",(unsigned long)p_ret);
-
-   return p_ret;
+   return NULL;
 }
 
 
 void p_rb_del_ed_pid(struct rb_root *p_root, struct p_ed_process *p_source) {
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_rb_del_ed_pid>\n");
-
    rb_erase(&p_source->p_rb, p_root);          // Erase the node
    p_reset_ed_flags(p_source);
    p_free_ed_pids(p_source);                   // Free the memory
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_rb_del_ed_pid>\n");
 }
 
 static void p_ed_pids_cache_init(void *p_arg) {
 
    struct p_ed_process *p_struct = p_arg;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_ed_pids_cache_init>\n");
-
    memset(p_struct, 0x0, sizeof(struct p_ed_process));
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_ed_pids_cache_init>\n");
 }
 
 int p_init_rb_ed_pids(void) {
 
-   int p_ret = P_LKRG_SUCCESS;
    unsigned int i;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_init_rb_ed_pids>\n");
 
    for (i=0; i < RB_HASH_SIZE; i++) {
       p_rb_hash[i].p_tree.tree = RB_ROOT;
@@ -143,14 +94,10 @@ int p_init_rb_ed_pids(void) {
    if ( (p_ed_pids_cache = kmem_cache_create("p_ed_pids", sizeof(struct p_ed_process),
                                            0x0, SLAB_HWCACHE_ALIGN, p_ed_pids_cache_init)) == NULL) {
       p_print_log(P_LKRG_ERR, "kmem_cache_create() for ED PIDs error! :(\n");
-      p_ret = -ENOMEM;
+      return -ENOMEM;
    }
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_init_rb_ed_pids> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 void p_delete_rb_ed_pids(void) {
@@ -158,10 +105,6 @@ void p_delete_rb_ed_pids(void) {
    struct rb_node *p_node;
    struct p_ed_process *p_tmp;
    unsigned int i;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_delete_rb_ed_pids>\n");
 
    if (p_ed_pids_cache) {
       for (i=0; i<RB_HASH_SIZE; i++) {
@@ -179,7 +122,4 @@ void p_delete_rb_ed_pids(void) {
       p_ed_pids_cache = NULL;
    }
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_delete_rb_ed_pids>\n");
 }

--- a/src/modules/exploit_detection/p_rb_ed_trees/p_rb_ed_pids/p_rb_ed_pids_tree.h
+++ b/src/modules/exploit_detection/p_rb_ed_trees/p_rb_ed_pids/p_rb_ed_pids_tree.h
@@ -96,18 +96,10 @@ static inline struct p_ed_process *p_find_ed_by_pid(pid_t p_arg) {
 
 static inline void p_rb_init_ed_pid_node(struct rb_node *rb) {
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_rb_init_ed_pid_node>\n");
-
    rb->__rb_parent_color = 0;
    rb->rb_right = NULL;
    rb->rb_left = NULL;
    RB_CLEAR_NODE(rb);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_rb_init_ed_pid_node>\n");
 }
 
 #endif

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_execve/p_x32_sys_execve.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_execve/p_x32_sys_execve.c
@@ -43,9 +43,6 @@ int p_x32_sys_execve_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_execve_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -54,8 +51,6 @@ int p_x32_sys_execve_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_execve_entry>\n");
 
    return 0;
 }
@@ -67,8 +62,6 @@ int p_x32_sys_execve_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_execve_ret>\n");
 /*
    p_inode = p_get_inode_from_task(current);
 
@@ -94,9 +87,6 @@ int p_x32_sys_execve_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_execve_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_execveat/p_x32_sys_execveat.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_execveat/p_x32_sys_execveat.c
@@ -43,9 +43,6 @@ int p_x32_sys_execveat_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_execveat_entry>\n");
-
 //   p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -54,9 +51,6 @@ int p_x32_sys_execveat_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_execveat_entry>\n");
 
    return 0;
 }
@@ -68,8 +62,6 @@ int p_x32_sys_execveat_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_execveat_ret>\n");
 /*
    p_inode = p_get_inode_from_task(current);
 
@@ -95,9 +87,6 @@ int p_x32_sys_execveat_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs
    p_tasks_write_unlock(&p_flags);
 
    p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_execveat_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
@@ -42,9 +42,6 @@ int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_keyctl_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -53,9 +50,6 @@ int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_keyctl_entry>\n");
 
    return 0x0;
 }
@@ -66,8 +60,6 @@ int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_keyctl_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -85,9 +77,6 @@ int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_keyctl_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_ptrace/p_x32_sys_ptrace.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_ptrace/p_x32_sys_ptrace.c
@@ -53,10 +53,6 @@ int p_x32_sys_ptrace_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_ptrace_entry>\n");
-
    p_tasks_read_lock(&p_flags);
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
       // This process is on the ED list - validate 'off' flag
@@ -66,25 +62,13 @@ int p_x32_sys_ptrace_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
 
    p_ed_enforce_validation();
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_ptrace_entry>\n");
-
    return 0x0;
 }
 
 
 int p_x32_sys_ptrace_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_x32_sys_ptrace_ret>\n");
-
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_x32_sys_ptrace_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
@@ -38,9 +38,6 @@ int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_cap_task_prctl_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_cap_task_prctl_entry>\n");
 
    return 0x0;
 }
@@ -63,8 +57,6 @@ int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    long p_ret = (long)p_regs_get_ret(p_regs);
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_cap_task_prctl_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -82,9 +74,6 @@ int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_cap_task_prctl_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
@@ -38,9 +38,6 @@ int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_capset_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_capset_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_capset_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_capset_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
@@ -45,9 +45,6 @@ int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_add_key_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -56,9 +53,6 @@ int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_add_key_entry>\n");
 
    return 0x0;
 }
@@ -69,8 +63,6 @@ int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_add_key_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -88,9 +80,6 @@ int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_add_key_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
@@ -45,9 +45,6 @@ int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_capset_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -56,9 +53,6 @@ int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_capset_entry>\n");
 
    return 0x0;
 }
@@ -69,8 +63,6 @@ int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_capset_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -88,9 +80,6 @@ int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_capset_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_execve/p_compat_sys_execve.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_execve/p_compat_sys_execve.c
@@ -41,9 +41,6 @@ int p_compat_sys_execve_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_execve_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -52,9 +49,6 @@ int p_compat_sys_execve_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_execve_entry>\n");
 
    return 0;
 }
@@ -66,8 +60,6 @@ int p_compat_sys_execve_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_execve_ret>\n");
 /*
    p_inode = p_get_inode_from_task(current);
 
@@ -93,9 +85,6 @@ int p_compat_sys_execve_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_execve_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_execveat/p_compat_sys_execveat.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_execveat/p_compat_sys_execveat.c
@@ -42,9 +42,6 @@ int p_compat_sys_execveat_entry(struct kretprobe_instance *p_ri, struct pt_regs 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_execveat_entry>\n");
-
 //   p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -53,9 +50,6 @@ int p_compat_sys_execveat_entry(struct kretprobe_instance *p_ri, struct pt_regs 
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_execveat_entry>\n");
 
    return 0;
 }
@@ -67,8 +61,6 @@ int p_compat_sys_execveat_ret(struct kretprobe_instance *ri, struct pt_regs *p_r
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_execveat_ret>\n");
 /*
    p_inode = p_get_inode_from_task(current);
 
@@ -94,9 +86,6 @@ int p_compat_sys_execveat_ret(struct kretprobe_instance *ri, struct pt_regs *p_r
    p_tasks_write_unlock(&p_flags);
 
    p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_execveat_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
@@ -40,9 +40,6 @@ int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_keyctl_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -51,9 +48,6 @@ int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_keyctl_entry>\n");
 
    return 0x0;
 }
@@ -64,8 +58,6 @@ int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_keyctl_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -83,9 +75,6 @@ int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_keyctl_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_ptrace/p_compat_sys_ptrace.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_ptrace/p_compat_sys_ptrace.c
@@ -51,10 +51,6 @@ int p_compat_sys_ptrace_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_ptrace_entry>\n");
-
    p_tasks_read_lock(&p_flags);
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
       // This process is on the ED list - validate 'off' flag
@@ -64,25 +60,13 @@ int p_compat_sys_ptrace_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
 
    p_ed_enforce_validation();
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_ptrace_entry>\n");
-
    return 0x0;
 }
 
 
 int p_compat_sys_ptrace_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_ptrace_ret>\n");
-
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_ptrace_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
@@ -45,9 +45,6 @@ int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_request_key_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -56,9 +53,6 @@ int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_re
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_request_key_entry>\n");
 
    return 0x0;
 }
@@ -69,8 +63,6 @@ int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_compat_sys_request_key_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -88,9 +80,6 @@ int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_compat_sys_request_key_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
@@ -38,18 +38,12 @@ int p_key_change_session_keyring_entry(struct kretprobe_instance *p_ri, struct p
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_key_change_session_keyring_entry>\n");
-
    p_tasks_write_lock(&p_flags);
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
       // This process is on the ED list - set temporary 'disable' flag!
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_key_change_session_keyring_entry>\n");
 
    return 0x0;
 }
@@ -60,8 +54,6 @@ int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_key_change_session_keyring_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -78,9 +70,6 @@ int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_re
    p_tasks_write_unlock(&p_flags);
 
    p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_key_change_session_keyring_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
@@ -38,9 +38,6 @@ int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs)
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_add_key_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs)
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_add_key_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_add_key_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_add_key_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
@@ -38,9 +38,6 @@ int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_keyctl_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_keyctl_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_keyctl_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_keyctl_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
@@ -38,9 +38,6 @@ int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_r
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_request_key_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_r
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_request_key_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs)
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_request_key_ret>\n");
    p_debug_kprobe_log(
           "capset returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs)
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_request_key_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_create_or_link/p_ovl_create_or_link.c
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_create_or_link/p_ovl_create_or_link.c
@@ -36,12 +36,6 @@ static struct kretprobe p_ovl_create_or_link_kretprobe = {
 
 int p_ovl_create_or_link_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-   p_debug_kprobe_log(
-          "Entering function <p_ovl_create_or_link_entry>\n");
-
-   p_debug_kprobe_log(
-          "Leaving function <p_ovl_create_or_link_entry>\n");
-
    return 0;
 }
 
@@ -50,9 +44,6 @@ int p_ovl_create_or_link_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
-
-   p_debug_kprobe_log(
-          "Entering function <p_ovl_create_or_link_ret>\n");
 
    if (p_is_ed_task(current)) {
       // Update process
@@ -70,9 +61,6 @@ int p_ovl_create_or_link_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
       }
       p_tasks_write_unlock(&p_flags);
    }
-
-   p_debug_kprobe_log(
-          "Leaving function <p_ovl_create_or_link_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
@@ -39,9 +39,6 @@ int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_override_creds_entry>\n");
-
    if (p_is_ed_task(current)) {
       p_tasks_write_lock(&p_flags);
       p_ed_validate_current();
@@ -57,9 +54,6 @@ int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
       p_tasks_write_unlock(&p_flags);
    }
 
-   p_debug_kprobe_log(
-          "Leaving function <p_override_creds_entry>\n");
-
    return 0;
 }
 
@@ -68,9 +62,6 @@ int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
-
-   p_debug_kprobe_log(
-          "Entering function <p_override_creds_ret>\n");
 
    if (p_is_ed_task(current)) {
       p_tasks_read_lock(&p_flags);
@@ -84,9 +75,6 @@ int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
       }
       p_tasks_read_unlock(&p_flags);
    }
-
-   p_debug_kprobe_log(
-          "Leaving function <p_override_creds_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
@@ -35,12 +35,6 @@ static struct kretprobe p_revert_creds_kretprobe = {
 
 int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-   p_debug_kprobe_log(
-          "Entering function <p_revert_creds_entry>\n");
-
-   p_debug_kprobe_log(
-          "Leaving function <p_revert_creds_entry>\n");
-
    return 0;
 }
 
@@ -49,9 +43,6 @@ int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
-
-   p_debug_kprobe_log(
-          "Entering function <p_revert_creds_ret>\n");
 
    if (p_is_ed_task(current)) {
       // Update process
@@ -68,9 +59,6 @@ int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
       p_ed_validate_current();
       p_tasks_write_unlock(&p_flags);
    }
-
-   p_debug_kprobe_log(
-          "Leaving function <p_revert_creds_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -48,10 +48,6 @@ int p_pcfi___queue_work_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
 
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi___queue_work_entry>\n");
-
    p_ed_pcfi_cpu(0);
 
    if (p_is_ed_task(current)) {
@@ -62,25 +58,13 @@ int p_pcfi___queue_work_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
       }
    }
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi___queue_work_entry>\n");
-
    return 0x0;
 }
 
 
 int p_pcfi___queue_work_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi___queue_work_ret>\n");
-
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi___queue_work_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
@@ -49,10 +49,6 @@ int p_pcfi_lookup_fast_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi_lookup_fast_entry>\n");
-
    p_ed_pcfi_cpu(1);
 
 //   p_ed_enforce_validation();
@@ -71,25 +67,13 @@ int p_pcfi_lookup_fast_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_
       p_tasks_read_unlock(&p_flags);
    }
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi_lookup_fast_entry>\n");
-
    return 0x0;
 }
 
 
 int p_pcfi_lookup_fast_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi_lookup_fast_ret>\n");
-
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi_lookup_fast_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
@@ -49,10 +49,6 @@ int p_pcfi_mark_inode_dirty_entry(struct kretprobe_instance *p_ri, struct pt_reg
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi_mark_inode_dirty_entry>\n");
-
    p_ed_pcfi_cpu(1);
 
 //   p_ed_enforce_validation();
@@ -100,24 +96,12 @@ int p_pcfi_mark_inode_dirty_entry(struct kretprobe_instance *p_ri, struct pt_reg
       p_tasks_read_unlock(&p_flags);
    }
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi_mark_inode_dirty_entry>\n");
-
    return 0x0;
 }
 
 int p_pcfi_mark_inode_dirty_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi_mark_inode_dirty_ret>\n");
-
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi_mark_inode_dirty_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
@@ -49,10 +49,6 @@ int p_pcfi_schedule_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi_schedule_entry>\n");
-
    p_ed_pcfi_cpu(1);
 
 //   p_ed_enforce_validation();
@@ -71,25 +67,13 @@ int p_pcfi_schedule_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
       p_tasks_read_unlock(&p_flags);
    }
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi_schedule_entry>\n");
-
    return 0x0;
 }
 
 
 int p_pcfi_schedule_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_pcfi_schedule_ret>\n");
-
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_pcfi_schedule_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -74,29 +74,20 @@ struct p_umh_path {
 
 static int p_check_if_file_exists(const char *p_arg) {
 
-   int p_ret = P_LKRG_SUCCESS;
    struct path p_path;
 
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_check_if_file_exists>\n");
    p_debug_log(P_LKRG_DBG,
           "Trying to resolve [%s]\n",p_arg);
 
-   if ( (p_ret = kern_path(p_arg, LOOKUP_FOLLOW, &p_path)) != P_LKRG_SUCCESS) {
+   if (kern_path(p_arg, LOOKUP_FOLLOW, &p_path) != P_LKRG_SUCCESS) {
       p_print_log(P_LKRG_INFO,
              "[kern_path] Can't resolve filename: [%s]\n",p_arg);
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_check_if_file_exists_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    path_put(&p_path);
 
-p_check_if_file_exists_out:
-
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_check_if_file_exists> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 void p_usermodehelper_init(void) {
@@ -125,9 +116,6 @@ int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs 
    unsigned long p_flags;
    struct p_umh_path p_umh_local[] = UMH_LIST;
    size_t i;
-
-   p_debug_kprobe_log(
-          "Entering function <p_call_usermodehelper_entry>\n");
 
    p_ed_enforce_validation();
 
@@ -244,22 +232,13 @@ p_call_usermodehelper_entry_not_allowed:
 
 p_call_usermodehelper_entry_out:
 
-   p_debug_kprobe_log(
-          "Leaving function <p_call_usermodehelper_entry>\n");
-
    return 0;
 }
 
 
 int p_call_usermodehelper_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
-   p_debug_kprobe_log(
-          "Entering function <p_call_usermodehelper_ret>\n");
-
    p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_call_usermodehelper_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
@@ -38,9 +38,6 @@ int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_call_usermodehelper_exec_entry>\n");
-
    p_ed_pcfi_cpu(1);
 
    if (p_is_ed_task(current)) {
@@ -57,19 +54,10 @@ int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_
       p_tasks_read_unlock(&p_flags);
    }
 
-   p_debug_kprobe_log(
-          "Leaving function <p_call_usermodehelper_exec_entry>\n");
-
    return 0;
 }
 
 int p_call_usermodehelper_exec_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
-
-   p_debug_kprobe_log(
-          "Entering function <p_call_usermodehelper_exec_ret>\n");
-
-   p_debug_kprobe_log(
-          "Leaving function <p_call_usermodehelper_exec_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
@@ -49,10 +49,6 @@ int p_capable_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp = NULL;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_capable_entry>\n");
-
    p_ed_pcfi_cpu(1);
 
 //   p_ed_enforce_validation();
@@ -72,23 +68,11 @@ int p_capable_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
       p_tasks_read_unlock(&p_flags);
    }
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_capable_entry>\n");
-
    return 0x0;
 }
 
 
 int p_capable_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_capable_ret>\n");
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_capable_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
@@ -40,8 +40,6 @@ int p_do_exit_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    unsigned long p_flags;
 
    p_debug_kprobe_log(
-          "Entering function <p_do_exit_entry>\n");
-   p_debug_kprobe_log(
           "p_do_exit_entry: comm[%s] Pid:%d\n",current->comm,current->pid);
 
 //   p_ed_enforce_validation();
@@ -58,9 +56,6 @@ int p_do_exit_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    }
    p_tasks_write_unlock(&p_flags);
 
-   p_debug_kprobe_log(
-          "Leaving function <p_do_exit_entry>\n");
-
    /* A dump_stack() here will give a stack backtrace */
    return 0x0;
 }
@@ -68,13 +63,8 @@ int p_do_exit_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
 int p_do_exit_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
-   p_debug_kprobe_log(
-          "Entering function <p_do_exit_ret>\n");
-
    p_ed_enforce_validation();
 
-   p_debug_kprobe_log(
-          "Leaving function <p_do_exit_ret>\n");
    return 0x0;
 }
 

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
@@ -67,10 +67,6 @@ int p_generic_permission_entry(struct kretprobe_instance *p_ri, struct pt_regs *
    struct p_ed_process *p_tmp = NULL;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_generic_permission_entry>\n");
-
    p_ed_pcfi_cpu(1);
 
    if (p_is_ed_task(current)) {
@@ -88,23 +84,11 @@ int p_generic_permission_entry(struct kretprobe_instance *p_ri, struct pt_regs *
       p_tasks_read_unlock(&p_flags);
    }
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_generic_permission_entry>\n");
-
    return 0x0;
 }
 
 
 int p_generic_permission_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_generic_permission_ret>\n");
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_generic_permission_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_install.c
+++ b/src/modules/exploit_detection/syscalls/p_install.c
@@ -26,10 +26,6 @@ int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
    const char *p_name = kretprobe->kp.symbol_name;
    struct p_isra_argument p_isra_arg;
 
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_install_hook> for %s\n",
-          p_name);
-
    if ( (p_ret = register_kretprobe(kretprobe)) < 0) {
       if (p_isra && p_ret == -22) {
          p_print_log(P_LKRG_WARN, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]\n",
@@ -42,7 +38,7 @@ int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
             if ( (p_ret = register_kretprobe(kretprobe)) < 0) {
                p_print_log(P_LKRG_ERR, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]\n",
                       p_name, p_ret);
-               goto p_install_hook_out;
+               return p_ret;
             }
             p_print_log(P_LKRG_WARN,
                         "ISRA / CONSTPROP version was found and hook was planted at <%s>\n",
@@ -52,12 +48,12 @@ int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
             p_print_log(P_LKRG_ERR,
                    "[kretprobe] register_kretprobe() for %s failed and ISRA / CONSTPROP version not found!\n",
                    p_isra_arg.p_name);
-            goto p_install_hook_out;
+            return p_ret;
          }
       } else {
          p_print_log(P_LKRG_ERR, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]\n",
                      p_name, p_ret);
-         goto p_install_hook_out;
+         return p_ret;
       }
    }
 
@@ -66,22 +62,12 @@ int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
                (unsigned long)kretprobe->kp.addr);
    (*state)++;
 
-p_install_hook_out:
-
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_install_hook> for %s (p_ret => %d)\n",
-          p_name, p_ret);
-
    return p_ret;
 }
 
 void p_uninstall_hook(struct kretprobe *kretprobe, char *state) {
 
    const char *p_name = kretprobe->kp.symbol_name;
-
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_uninstall_hook> for %s\n",
-           p_name);
 
    if (!*state) {
       p_print_log(P_LKRG_INFO, "[kretprobe] <%s> at 0x%lx is NOT installed\n",
@@ -101,8 +87,4 @@ void p_uninstall_hook(struct kretprobe *kretprobe, char *state) {
       }
       *state = 0x0;
    }
-
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_uninstall_hook> %s\n",
-          p_name);
 }

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
@@ -36,25 +36,13 @@ static struct kretprobe p_scm_send_kretprobe = {
 
 int p_scm_send_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-   p_debug_kprobe_log(
-          "Entering function <p_scm_send_entry>\n");
-
    p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_scm_send_entry>\n");
 
    return 0x0;
 }
 
 
 int p_scm_send_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
-
-   p_debug_kprobe_log(
-          "Entering function <p_scm_send_ret>\n");
-
-   p_debug_kprobe_log(
-          "Leaving function <p_scm_send_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
@@ -53,10 +53,6 @@ int p_seccomp_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_seccomp_entry>\n");
-
 //   p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -90,10 +86,6 @@ int p_seccomp_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    }
    p_tasks_write_unlock(&p_flags);
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_seccomp_entry>\n");
-
    return 0x0;
 }
 
@@ -104,9 +96,6 @@ int p_seccomp_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    char p_update = ((long)p_regs_get_ret(p_regs) >= 0) ? 1 : 0;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_seccomp_ret>\n");
    // Update process
    p_tasks_write_lock(&p_flags);
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
@@ -149,10 +138,6 @@ int p_seccomp_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_seccomp_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
@@ -51,10 +51,6 @@ int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_sel_write_enforce_entry>\n");
-
    p_tasks_read_lock(&p_flags);
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
       // This process is on the ED list - validate 'off' flag
@@ -69,19 +65,11 @@ int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    p_lkrg_selinux_lock_val_inc(&p_ed_guard_globals.p_selinux_lock);
    p_lkrg_selinux_lock_unlock(&p_ed_guard_globals.p_selinux_lock, &p_flags);
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_sel_write_enforce_entry>\n");
-
    return 0x0;
 }
 
 
 int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_sel_write_enforce_ret>\n");
 
    // Success ?
    if (!IS_ERR((void *)p_regs_get_ret(p_regs))) {
@@ -102,10 +90,6 @@ int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_r
    p_lkrg_selinux_lock_val_dec(&p_ed_guard_globals.p_selinux_lock);
 
    p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_sel_write_enforce_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
@@ -38,9 +38,6 @@ int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_set_current_groups_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_set_current_groups_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_set_current_groups_ret>\n");
    p_debug_kprobe_log(
           "setgroups returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_set_current_groups_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_execve/p_sys_execve.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_execve/p_sys_execve.c
@@ -39,11 +39,8 @@ struct inode *p_get_inode_from_task(struct task_struct *p_arg) {
    struct mm_struct *p_mm;
    struct inode *p_inode = NULL;
 
-   p_debug_kprobe_log(
-          "Entering function <p_get_inode_from_task>\n");
-
    if (!p_arg) {
-      goto p_get_inode_from_task_out;
+      return NULL;
    }
 
    /*
@@ -68,12 +65,6 @@ struct inode *p_get_inode_from_task(struct task_struct *p_arg) {
 
 //   up_read(&p_arg->mm->mmap_sem);
 
-
-p_get_inode_from_task_out:
-
-   p_debug_kprobe_log(
-          "Leaving function <p_get_inode_from_task> (p_inode => 0x%lx)\n",(unsigned long)p_inode);
-
    return p_inode;
 }
 
@@ -81,9 +72,6 @@ int p_sys_execve_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
-
-   p_debug_kprobe_log(
-          "Entering function <p_sys_execve_entry>\n");
 
    p_ed_enforce_validation();
 
@@ -93,9 +81,6 @@ int p_sys_execve_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_execve_entry>\n");
 
    return 0;
 }
@@ -107,8 +92,6 @@ int p_sys_execve_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_execve_ret>\n");
 /*
    p_inode = p_get_inode_from_task(current);
 
@@ -134,9 +117,6 @@ int p_sys_execve_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_execve_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_execveat/p_sys_execveat.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_execveat/p_sys_execveat.c
@@ -40,9 +40,6 @@ int p_sys_execveat_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_execveat_entry>\n");
-
 //   p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -51,9 +48,6 @@ int p_sys_execveat_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_execveat_entry>\n");
 
    return 0;
 }
@@ -65,8 +59,6 @@ int p_sys_execveat_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_execveat_ret>\n");
 /*
    p_inode = p_get_inode_from_task(current);
 
@@ -92,9 +84,6 @@ int p_sys_execveat_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
    p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_execveat_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_ptrace/p_sys_ptrace.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_ptrace/p_sys_ptrace.c
@@ -49,10 +49,6 @@ int p_sys_ptrace_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_sys_ptrace_entry>\n");
-
    p_tasks_read_lock(&p_flags);
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
       // This process is on the ED list - validate 'off' flag
@@ -62,25 +58,13 @@ int p_sys_ptrace_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
 
    p_ed_enforce_validation();
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_ptrace_entry>\n");
-
    return 0x0;
 }
 
 
 int p_sys_ptrace_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_sys_ptrace_ret>\n");
-
 //   p_ed_enforce_validation();
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_ptrace_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
@@ -38,9 +38,6 @@ int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setfsgid_entry>\n");
-
    /*
     * This is special case, since we can NOT identify when syscall fail or succeed,
     * we must verify process list before and after the syscall
@@ -54,9 +51,6 @@ int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    }
    p_tasks_write_unlock(&p_flags);
 
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setfsgid_entry>\n");
-
    return 0x0;
 }
 
@@ -66,8 +60,6 @@ int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setfsgid_ret>\n");
    p_debug_kprobe_log(
           "Setfsgid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -86,9 +78,6 @@ int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setfsgid_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
@@ -38,9 +38,6 @@ int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setfsuid_entry>\n");
-
    /*
     * This is special case, since we can NOT identify when syscall fail or succeed,
     * we must verify process list before and after the syscall
@@ -54,9 +51,6 @@ int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    }
    p_tasks_write_unlock(&p_flags);
 
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setfsuid_entry>\n");
-
    return 0x0;
 }
 
@@ -66,8 +60,6 @@ int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setfsuid_ret>\n");
    p_debug_kprobe_log(
           "Setfsuid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -86,9 +78,6 @@ int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setfsuid_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
@@ -38,9 +38,6 @@ int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setgid_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setgid_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setgid_ret>\n");
    p_debug_kprobe_log(
           "Setgid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setgid_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
@@ -38,9 +38,6 @@ int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setns_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setns_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setns_ret>\n");
    p_debug_kprobe_log(
           "sys_setns returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setns_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
@@ -38,9 +38,6 @@ int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setregid_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setregid_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setregid_ret>\n");
    p_debug_kprobe_log(
           "Setregid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setregid_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
@@ -38,9 +38,6 @@ int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setresgid_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setresgid_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setresgid_ret>\n");
    p_debug_kprobe_log(
           "Setresgid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setresgid_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
@@ -38,9 +38,6 @@ int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setresuid_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setresuid_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setresuid_ret>\n");
    p_debug_kprobe_log(
           "Setresuid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -82,12 +74,8 @@ int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
 //   p_ed_enforce_validation();
 
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setresuid_ret>\n");
-
    return 0x0;
 }
 
 
 GENERATE_INSTALL_FUNC(sys_setresuid)
-

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
@@ -38,9 +38,6 @@ int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setreuid_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setreuid_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setreuid_ret>\n");
    p_debug_kprobe_log(
           "Setreuid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setreuid_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
@@ -38,9 +38,6 @@ int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setuid_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -49,9 +46,6 @@ int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setuid_entry>\n");
 
    return 0x0;
 }
@@ -62,8 +56,6 @@ int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_setuid_ret>\n");
    p_debug_kprobe_log(
           "Setuid returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -81,9 +73,6 @@ int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_setuid_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
@@ -42,9 +42,6 @@ int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs)
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_unshare_entry>\n");
-
    p_ed_enforce_validation();
 
    p_tasks_write_lock(&p_flags);
@@ -53,9 +50,6 @@ int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs)
       p_set_ed_process_off(p_tmp);
    }
    p_tasks_write_unlock(&p_flags);
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_unshare_entry>\n");
 
    return 0x0;
 }
@@ -66,8 +60,6 @@ int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
 
-   p_debug_kprobe_log(
-          "Entering function <p_sys_unshare_ret>\n");
    p_debug_kprobe_log(
           "unshare returned value => %ld comm[%s] Pid:%d parent[%d]\n",
                        p_regs_get_ret(p_regs),current->comm,current->pid,current->real_parent->pid);
@@ -85,9 +77,6 @@ int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_sys_unshare_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_ttwu_do_wakeup/p_ttwu_do_wakeup.c
+++ b/src/modules/exploit_detection/syscalls/p_ttwu_do_wakeup/p_ttwu_do_wakeup.c
@@ -50,10 +50,6 @@ int p_ttwu_do_wakeup_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    struct task_struct *p_task = (struct task_struct *)p_regs_get_arg2(p_regs);
    unsigned long p_flags;
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_ttwu_do_wakeup_entry>\n");
-
    p_ed_pcfi_cpu(0);
 
    if (p_is_ed_task(p_task)) {
@@ -64,24 +60,11 @@ int p_ttwu_do_wakeup_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
       }
    }
 
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_ttwu_do_wakeup_entry>\n");
-
    return 0x0;
 }
 
 
 int p_ttwu_do_wakeup_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Entering function <p_ttwu_do_wakeup_ret>\n");
-
-
-// STRONG_DEBUG
-   p_debug_kprobe_log(
-          "Leaving function <p_ttwu_do_wakeup_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -75,13 +75,7 @@ int p_wake_up_new_task_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_
 
 int p_wake_up_new_task_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
-   p_debug_kprobe_log(
-          "Entering function <p_wake_up_new_task_ret>\n");
-
 //   p_ed_enforce_validation();
-
-   p_debug_kprobe_log(
-          "Leaving function <p_wake_up_new_task_ret>\n");
 
    return 0x0;
 }

--- a/src/modules/integrity_timer/p_integrity_timer.c
+++ b/src/modules/integrity_timer/p_integrity_timer.c
@@ -36,62 +36,30 @@ static void p_offload_cache_zero(void *p_arg) {
 
    struct work_struct *p_struct = p_arg;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_offload_cache_zero>\n");
-
    memset(p_struct, 0x0, sizeof(struct work_struct));
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_offload_cache_zero>\n");
-
 }
 
 int p_offload_cache_init(void) {
 
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_offload_cache_init>\n");
-
    if ( (p_offload_cache = kmem_cache_create("p_offload_cache", sizeof(struct work_struct),
                                              0x0, SLAB_HWCACHE_ALIGN, p_offload_cache_zero)) == NULL) {
       p_print_log(P_LKRG_ERR, "kmem_cache_create() for offloading error! :(\n");
-      p_ret = -ENOMEM;
+      return -ENOMEM;
    }
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_offload_cache_init> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 void p_offload_cache_delete(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_offload_cache_delete>\n");
 
    flush_workqueue(system_unbound_wq);
    if (p_offload_cache) {
       kmem_cache_destroy(p_offload_cache);
       p_offload_cache = NULL;
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_offload_cache_delete>\n");
-
 }
 
 void p_integrity_timer(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_integrity_timer>\n");
 
    p_timer.expires    = jiffies + P_CTRL(p_interval)*HZ;
 
@@ -103,11 +71,6 @@ void p_integrity_timer(void) {
    timer_setup(&p_timer, p_offload_work, 0);
 #endif
    add_timer(&p_timer);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_integrity_timer>\n");
-
 }
 
 
@@ -119,9 +82,6 @@ void p_offload_work(struct timer_list *p_timer) {
 
    struct work_struct *p_worker;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_offload_work>\n");
    p_debug_log(P_LKRG_STRONG_DBG,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
           "p_timer => %ld\n",p_timer);
@@ -135,11 +95,6 @@ void p_offload_work(struct timer_list *p_timer) {
    queue_work(system_unbound_wq, p_worker);
    if (p_timer)
       p_integrity_timer();
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_offload_work>\n");
-
 }
 
 
@@ -162,10 +117,6 @@ void p_check_integrity(struct work_struct *p_work) {
    struct module *p_tmp_mod;
    unsigned int p_tmp = 0x0;
    int p_ret;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_check_integrity>\n");
 
    if (!P_CTRL(p_kint_validate) || (!p_manual && P_CTRL(p_kint_validate) == 1))
       goto p_check_integrity_tasks;
@@ -1861,9 +1812,4 @@ p_check_integrity_tasks:
    if (p_work) {
       p_free_offload(p_work);
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_check_integrity>\n");
-
 }

--- a/src/modules/kmod/p_kmod.c
+++ b/src/modules/kmod/p_kmod.c
@@ -27,12 +27,6 @@
 
 int p_kmod_init(void) {
 
-   int p_ret = P_LKRG_SUCCESS;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_kmod_init>\n");
-
 #if defined(CONFIG_DYNAMIC_DEBUG)
    P_SYM(p_ddebug_tables)    = (struct list_head *)P_SYM(p_kallsyms_lookup_name)("ddebug_tables");
    P_SYM(p_ddebug_lock)      = (struct mutex *)P_SYM(p_kallsyms_lookup_name)("ddebug_lock");
@@ -80,8 +74,7 @@ int p_kmod_init(void) {
    if (!P_SYM(p_global_modules)) {
       p_print_log(P_LKRG_ERR,
              "KMOD error! Can't initialize global modules variable :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_kmod_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
 #if defined(CONFIG_DYNAMIC_DEBUG)
@@ -89,8 +82,7 @@ int p_kmod_init(void) {
    if (!P_SYM(p_ddebug_remove_module_ptr)) {
       p_print_log(P_LKRG_ERR,
              "KMOD error! Can't find 'ddebug_remove_module' function :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_kmod_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
  #endif
 #endif
@@ -99,39 +91,26 @@ int p_kmod_init(void) {
    if (!P_SYM(p_kernfs_mutex)) {
       p_print_log(P_LKRG_ERR,
              "KMOD error! Can't find 'kernfs_mutex' variable :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_kmod_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 #endif
 
    if (!P_SYM(p_module_kset)) {
       p_print_log(P_LKRG_ERR,
              "KMOD error! Can't find 'module_kset' variable :( Exiting...\n");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_kmod_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
-
-p_kmod_init_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_kmod_init> (p_ret => %d)\n",p_ret);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 /*
  * 'module_lock' must be taken by calling function!
  */
-unsigned int p_count_modules_from_module_list(void) {
+static unsigned int p_count_modules_from_module_list(void) {
 
    unsigned int p_cnt = 0x0;
    struct module *p_mod;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_count_modules_from_module_list>\n");
 
 //   mutex_lock(&module_mutex);
    list_for_each_entry(p_mod, P_SYM(p_global_modules), list) {
@@ -156,11 +135,6 @@ unsigned int p_count_modules_from_module_list(void) {
    }
 //   mutex_unlock(&module_mutex);
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Leaving function <p_count_modules_from_module_list> (p_cnt => %d)\n",p_cnt);
-
    return p_cnt;
 }
 
@@ -169,15 +143,10 @@ unsigned int p_count_modules_from_module_list(void) {
  *
  * 'module_lock' must be taken by calling function!
  */
-int p_list_from_module_list(p_module_list_mem *p_arg, char p_flag) {
+static int p_list_from_module_list(p_module_list_mem *p_arg, char p_flag) {
 
    struct module *p_mod;
-   int p_ret = P_LKRG_SUCCESS;
    unsigned int p_cnt = 0x0;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_list_from_module_list>\n");
 
 //   mutex_lock(&module_mutex);
    list_for_each_entry(p_mod, P_SYM(p_global_modules), list) {
@@ -224,12 +193,7 @@ int p_list_from_module_list(p_module_list_mem *p_arg, char p_flag) {
    }
 //   mutex_unlock(&module_mutex);
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Leaving function <p_list_from_module_list> (p_ret => %d | p_cnt => %d)\n",p_ret, p_cnt);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 /*
@@ -242,10 +206,6 @@ unsigned int p_count_modules_from_sysfs_kobj(void) {
    struct kobject *p_kobj = NULL, *p_tmp_safe = NULL;
    struct module_kobject *p_mk = NULL;
    unsigned int p_cnt = 0x0;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_count_modules_from_sysfs_kobj>\n");
 
    kset_get(p_kset);
    spin_lock(&p_kset->list_lock);
@@ -297,29 +257,19 @@ unsigned int p_count_modules_from_sysfs_kobj(void) {
    spin_unlock(&p_kset->list_lock);
    kset_put(p_kset);
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Leaving function <p_count_modules_from_sysfs_kobj> (p_cnt => %d)\n",p_cnt);
-
    return p_cnt;
 }
 
 /*
  * 'module_lock' must be taken by calling function!
  */
-int p_list_from_sysfs_kobj(p_module_kobj_mem *p_arg) {
+static int p_list_from_sysfs_kobj(p_module_kobj_mem *p_arg) {
 
    struct module *p_mod = NULL;
    struct kset *p_kset = *P_SYM(p_module_kset);
    struct kobject *p_kobj = NULL, *p_tmp_safe = NULL;
    struct module_kobject *p_mk = NULL;
-   int p_ret = P_LKRG_SUCCESS;
    unsigned int p_cnt = 0x0;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_list_from_sysfs_kobj>\n");
 
    kset_get(p_kset);
    spin_lock(&p_kset->list_lock);
@@ -417,12 +367,7 @@ int p_list_from_sysfs_kobj(p_module_kobj_mem *p_arg) {
    spin_unlock(&p_kset->list_lock);
    kset_put(p_kset);
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-//   p_print_log(P_LKRG_CRIT,
-          "Leaving function <p_list_from_sysfs_kobj> (p_cnt => %d)\n",p_cnt);
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 }
 
 /*
@@ -434,10 +379,6 @@ int p_kmod_hash(unsigned int *p_module_list_cnt_arg, p_module_list_mem **p_mlm_t
    int p_ret = P_LKRG_GENERAL_ERROR;
    unsigned int p_module_list_cnt_arg_old = *p_module_list_cnt_arg;
    unsigned int p_module_kobj_cnt_arg_old = *p_module_kobj_cnt_arg;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_kmod_hash>\n");
 
    /*
     * Originally this mutex was taken here. Unfortunately some use cases of this function
@@ -718,10 +659,6 @@ p_kmod_hash_err:
     * 'module_mutex'
     */
 //   mutex_unlock(&module_mutex);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_kmod_hash> (%s)\n",(p_ret == P_LKRG_SUCCESS) ? "SUCCESS" : "ERROR");
 
    return p_ret;
 }

--- a/src/modules/kmod/p_kmod_notifier.c
+++ b/src/modules/kmod/p_kmod_notifier.c
@@ -2,7 +2,7 @@
  * pi3's Linux kernel Runtime Guard
  *
  * Component:
- *  - Kernel's modules module notifier 
+ *  - Kernel's modules module notifier
  *
  * Notes:
  *  - Register notifier function whenever there is any kernel module load/unload activity
@@ -34,17 +34,9 @@ static struct notifier_block p_module_block_notifier = {
 static void p_module_notifier_wrapper(unsigned long p_event, struct module *p_kmod) {
 
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_module_notifier_wrapper>\n");
-
    if (P_CTRL(p_block_modules)) {
       p_kmod->init = p_block_always;
    }
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_module_notifier_wrapper>\n");
 
    return;
 }
@@ -278,10 +270,6 @@ p_module_event_notifier_activity_out:
 
    /* Inform validation routine about active module activities... */
    mutex_unlock(&p_module_activity);
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_module_event_notifier>\n");
 
    return NOTIFY_DONE;
 }

--- a/src/modules/notifiers/p_notifiers.c
+++ b/src/modules/notifiers/p_notifiers.c
@@ -106,10 +106,6 @@ static struct notifier_block p_acpi_notifier_nb = {
 
 void p_register_notifiers(void) {
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_register_notifiers>\n");
-
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0) &&  defined(_ASM_X86_IDLE_H)
    idle_notifier_register(&p_idle_notifier_nb);
 #endif
@@ -132,26 +128,13 @@ void p_register_notifiers(void) {
 #if defined(CONFIG_ACPI)
    register_acpi_notifier(&p_acpi_notifier_nb);
 #endif
-
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_register_notifiers>\n");
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0) && defined(_ASM_X86_IDLE_H)
 static int p_idle_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_idle_notifier>\n");
-
    /* 0.005% */
    P_TRY_OFFLOAD_NOTIFIER(P_M_SS_MORE_OFTEN_RATE, "<p_idle_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_idle_notifier>\n");
 
    return 0x0;
 }
@@ -160,18 +143,10 @@ static int p_idle_notifier(struct notifier_block *p_nb, unsigned long p_val, voi
 #ifdef CONFIG_CPU_FREQ
 static int p_freq_transition_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_freq_transition_notifier>\n");
-
    /* 10% */
 //   P_TRY_OFFLOAD_NOTIFIER(P_RARE_RATE, "<p_freq_transition_notifier> Offloading integrity check\n");
    /* 1%% */
    P_TRY_OFFLOAD_NOTIFIER(P_OFTEN_RATE, "<p_freq_transition_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_freq_transition_notifier>\n");
 
    return 0x0;
 }
@@ -179,48 +154,24 @@ static int p_freq_transition_notifier(struct notifier_block *p_nb, unsigned long
 
 static int p_cpu_pm_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_cpu_pm_notifier>\n");
-
    /* 10% */
    P_TRY_OFFLOAD_NOTIFIER(P_RARE_RATE, "<p_cpu_pm_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_cpu_pm_notifier>\n");
 
    return 0x0;
 }
 
 static int p_netdevice_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_netdevice_notifier>\n");
-
    /* 1% */
    P_TRY_OFFLOAD_NOTIFIER(P_OFTEN_RATE, "<p_netdevice_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_netdevice_notifier>\n");
 
    return 0x0;
 }
 
 static int p_netevent_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_netevent_notifier>\n");
-
    /* 5% */
    P_TRY_OFFLOAD_NOTIFIER(P_LESS_RARE_RATE, "<p_netevent_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_netevent_notifier>\n");
 
    return 0x0;
 }
@@ -228,16 +179,8 @@ static int p_netevent_notifier(struct notifier_block *p_nb, unsigned long p_val,
 #if IS_ENABLED(CONFIG_IPV6)
 static int p_inet6addr_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_inet6addr_notifier>\n");
-
    /* 100% */
    P_TRY_OFFLOAD_NOTIFIER_ALWAYS("<p_inet6addr_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_inet6addr_notifier>\n");
 
    return 0x0;
 }
@@ -245,64 +188,32 @@ static int p_inet6addr_notifier(struct notifier_block *p_nb, unsigned long p_val
 
 static int p_inetaddr_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_inetaddr_notifier>\n");
-
    /* 100% */
    P_TRY_OFFLOAD_NOTIFIER_ALWAYS("<p_inetaddr_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_inetaddr_notifier>\n");
 
    return 0x0;
 }
 
 static int p_taskfree_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_taskfree_notifier>\n");
-
    /* 0.01% */
    P_TRY_OFFLOAD_NOTIFIER(P_SS_MORE_OFTEN_RATE, "<p_taskfree_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_taskfree_notifier>\n");
 
    return 0x0;
 }
 
 static int p_profile_event_exit_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_profile_event_exit_notifier>\n");
-
    /* 0.01% */
    P_TRY_OFFLOAD_NOTIFIER(P_SS_MORE_OFTEN_RATE, "<p_profile_event_exit_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_profile_event_exit_notifier>\n");
 
    return 0x0;
 }
 
 static int p_profile_event_munmap_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_profile_event_munmap_notifier>\n");
-
    /* 0.005%*/
    P_TRY_OFFLOAD_NOTIFIER(P_M_SS_MORE_OFTEN_RATE, "<p_profile_event_munmap_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_profile_event_munmap_notifier>\n");
 
    return 0x0;
 }
@@ -310,16 +221,8 @@ static int p_profile_event_munmap_notifier(struct notifier_block *p_nb, unsigned
 #if defined(CONFIG_USB)
 static int p_usb_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_usb_notifier>\n");
-
    /* 100% */
    P_TRY_OFFLOAD_NOTIFIER_ALWAYS("<p_usb_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_usb_notifier>\n");
 
    return 0x0;
 }
@@ -328,16 +231,8 @@ static int p_usb_notifier(struct notifier_block *p_nb, unsigned long p_val, void
 #if defined(CONFIG_ACPI)
 static int p_acpi_notifier(struct notifier_block *p_nb, unsigned long p_val, void *p_data) {
 
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Entering function <p_acpi_notifier>\n");
-
    /* 100% */
    P_TRY_OFFLOAD_NOTIFIER_ALWAYS("<p_acpi_notifier> Offloading integrity check\n");
-
-// STRONG_DEBUG
-   p_debug_notifier_log(
-          "Leaving function <p_acpi_notifier>\n");
 
    return 0x0;
 }
@@ -345,10 +240,6 @@ static int p_acpi_notifier(struct notifier_block *p_nb, unsigned long p_val, voi
 
 
 void p_deregister_notifiers(void) {
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_deregister_notifiers>\n");
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0) && defined(_ASM_X86_IDLE_H)
    idle_notifier_unregister(&p_idle_notifier_nb);
@@ -372,9 +263,4 @@ void p_deregister_notifiers(void) {
 #if defined(CONFIG_ACPI)
    unregister_acpi_notifier(&p_acpi_notifier_nb);
 #endif
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_deregister_notifiers>\n");
-
 }

--- a/src/modules/print_log/p_lkrg_debug_log.c
+++ b/src/modules/print_log/p_lkrg_debug_log.c
@@ -1,0 +1,198 @@
+/*
+ * pi3's Linux kernel Runtime Guard
+ *
+ * Component:
+ *  - Debug module
+ *
+ * Notes:
+ *  - None
+ *
+ * Timeline:
+ *  - Created: 14.V.2020
+ *
+ * Author:
+ *  - Mariusz Zaborski (https://oshogbo.vexillium.org/)
+ *
+ */
+
+#include "../../p_lkrg_main.h"
+#include "../database/p_database.h"
+
+#define P_LKRG_DEBUG_RULE(fname) { (uintptr_t)fname, #fname }
+#define P_LKRG_DEBUG_RULE_KPROBE(fname)                        \
+   P_LKRG_DEBUG_RULE(fname##_entry),                           \
+   P_LKRG_DEBUG_RULE(fname##_ret)
+
+void __cyg_profile_func_enter(void *this_fn, void *call_site)
+__attribute__((no_instrument_function));
+void __cyg_profile_func_exit(void *this_fn, void *call_site)
+__attribute__((no_instrument_function));
+
+#ifdef P_LKRG_DEBUG_BUILD
+static struct p_addr_name {
+    uintptr_t	addr;
+    const char *name;
+} p_addr_name_array[] = {
+   P_LKRG_DEBUG_RULE(p_rb_add_ed_pid),
+   P_LKRG_DEBUG_RULE(p_rb_del_ed_pid),
+   P_LKRG_DEBUG_RULE(p_init_rb_ed_pids),
+   P_LKRG_DEBUG_RULE(p_delete_rb_ed_pids),
+   P_LKRG_DEBUG_RULE(p_dump_task_f),
+   P_LKRG_DEBUG_RULE(p_remove_task_pid_f),
+   P_LKRG_DEBUG_RULE(p_ed_enforce_validation),
+   P_LKRG_DEBUG_RULE(p_ed_enforce_validation_paranoid),
+   P_LKRG_DEBUG_RULE(p_exploit_detection_init),
+   P_LKRG_DEBUG_RULE(p_exploit_detection_exit),
+   P_LKRG_DEBUG_RULE(p_install_hook),
+   P_LKRG_DEBUG_RULE(p_uninstall_hook),
+   P_LKRG_DEBUG_RULE(p_kmod_init),
+   P_LKRG_DEBUG_RULE(p_kmod_hash),
+   P_LKRG_DEBUG_RULE(p_offload_cache_init),
+   P_LKRG_DEBUG_RULE(p_offload_cache_delete),
+   P_LKRG_DEBUG_RULE(p_integrity_timer),
+   P_LKRG_DEBUG_RULE(p_offload_work),
+   P_LKRG_DEBUG_RULE(p_check_integrity),
+   P_LKRG_DEBUG_RULE(p_register_comm_channel),
+   P_LKRG_DEBUG_RULE(p_deregister_comm_channel),
+   P_LKRG_DEBUG_RULE(p_get_cpus),
+   P_LKRG_DEBUG_RULE(p_cmp_cpus),
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+   P_LKRG_DEBUG_RULE(p_cpu_callback),
+#endif
+   P_LKRG_DEBUG_RULE(p_cpu_online_action),
+   P_LKRG_DEBUG_RULE(p_cpu_dead_action),
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
+   P_LKRG_DEBUG_RULE(p_install_switch_idt_hook),
+   P_LKRG_DEBUG_RULE(p_uninstall_switch_idt_hook),
+#endif
+   P_LKRG_DEBUG_RULE(p_register_arch_metadata),
+   P_LKRG_DEBUG_RULE(p_unregister_arch_metadata),
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+   P_LKRG_DEBUG_RULE(p_install_arch_jump_label_transform_hook),
+   P_LKRG_DEBUG_RULE(p_uninstall_arch_jump_label_transform_hook),
+   P_LKRG_DEBUG_RULE(p_install_arch_jump_label_transform_apply_hook),
+   P_LKRG_DEBUG_RULE(p_uninstall_arch_jump_label_transform_apply_hook),
+#endif
+   P_LKRG_DEBUG_RULE(hash_from_ex_table),
+   P_LKRG_DEBUG_RULE(hash_from_kernel_stext),
+   P_LKRG_DEBUG_RULE(hash_from_kernel_rodata),
+   P_LKRG_DEBUG_RULE(hash_from_iommu_table),
+   P_LKRG_DEBUG_RULE(hash_from_CPU_data),
+   P_LKRG_DEBUG_RULE(p_create_database),
+   P_LKRG_DEBUG_RULE(p_register_notifiers),
+   P_LKRG_DEBUG_RULE(p_deregister_notifiers),
+   P_LKRG_DEBUG_RULE(p_hide_itself),
+
+#ifdef P_LKRG_UNHIDE
+   P_LKRG_DEBUG_RULE(p_unhide_itself),
+#endif
+
+   P_LKRG_DEBUG_RULE(get_kallsyms_address),
+
+#ifdef CONFIG_X86
+   P_LKRG_DEBUG_RULE(p_read_msr),
+   P_LKRG_DEBUG_RULE(p_dump_x86_metadata),
+#endif
+
+#if defined(CONFIG_ARM)
+   P_LKRG_DEBUG_RULE(p_dump_arm_metadata),
+#endif
+
+#if defined(CONFIG_ARM64)
+   P_LKRG_DEBUG_RULE(p_dump_arm64_metadata),
+#endif
+
+#ifdef P_LKRG_STRONG_KPROBE_DEBUG
+   P_LKRG_DEBUG_RULE_KPROBE(p_cap_task_prctl),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_capset),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setuid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setregid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setns),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_unshare),
+   P_LKRG_DEBUG_RULE_KPROBE(p_generic_permission),
+   P_LKRG_DEBUG_RULE_KPROBE(p_scm_send),
+   P_LKRG_DEBUG_RULE_KPROBE(p_seccomp),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setresgid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_ptrace),
+   P_LKRG_DEBUG_RULE_KPROBE(p_compat_sys_execve),
+   P_LKRG_DEBUG_RULE_KPROBE(p_compat_sys_ptrace),
+   P_LKRG_DEBUG_RULE_KPROBE(p_compat_sys_add_key),
+   P_LKRG_DEBUG_RULE_KPROBE(p_compat_sys_capset),
+   P_LKRG_DEBUG_RULE_KPROBE(p_compat_sys_keyctl),
+   P_LKRG_DEBUG_RULE_KPROBE(p_compat_sys_request_key),
+   P_LKRG_DEBUG_RULE_KPROBE(p_compat_sys_execveat),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setfsgid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_call_usermodehelper_exec),
+   P_LKRG_DEBUG_RULE_KPROBE(p_set_current_groups),
+   P_LKRG_DEBUG_RULE_KPROBE(p_ovl_create_or_link),
+   P_LKRG_DEBUG_RULE_KPROBE(p_revert_creds),
+   P_LKRG_DEBUG_RULE_KPROBE(p_override_creds),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_execve),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setresuid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_keyctl),
+   P_LKRG_DEBUG_RULE_KPROBE(p_key_change_session_keyring),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_add_key),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_request_key),
+   P_LKRG_DEBUG_RULE_KPROBE(p_capable),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sel_write_enforce),
+   P_LKRG_DEBUG_RULE_KPROBE(p_pcfi___queue_work),
+   P_LKRG_DEBUG_RULE_KPROBE(p_pcfi_schedule),
+   P_LKRG_DEBUG_RULE_KPROBE(p_pcfi_lookup_fast),
+   P_LKRG_DEBUG_RULE_KPROBE(p_pcfi_mark_inode_dirty),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setreuid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setgid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_call_usermodehelper),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_execveat),
+   P_LKRG_DEBUG_RULE_KPROBE(p_ttwu_do_wakeup),
+   P_LKRG_DEBUG_RULE_KPROBE(p_x32_sys_ptrace),
+   P_LKRG_DEBUG_RULE_KPROBE(p_x32_sys_execve),
+   P_LKRG_DEBUG_RULE_KPROBE(p_x32_sys_execveat),
+   P_LKRG_DEBUG_RULE_KPROBE(p_x32_sys_keyctl),
+   P_LKRG_DEBUG_RULE_KPROBE(p_sys_setfsuid),
+   P_LKRG_DEBUG_RULE_KPROBE(p_do_exit),
+   P_LKRG_DEBUG_RULE_KPROBE(p_wake_up_new_task),
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
+   P_LKRG_DEBUG_RULE_KPROBE(p_switch_idt),
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+   P_LKRG_DEBUG_RULE_KPROBE(p_arch_jump_label_transform),
+   P_LKRG_DEBUG_RULE_KPROBE(p_arch_jump_label_transform_apply),
+#endif
+#endif
+
+   // Disable to noisy.
+   // P_LKRG_DEBUG_RULE(p_ed_enforce_pcfi),
+   // P_LKRG_DEBUG_RULE(p_rb_find_ed_pid),
+   // P_LKRG_DEBUG_RULE(p_validate_task_f),
+   // P_LKRG_DEBUG_RULE(p_ed_wq_valid_cache_init),
+   // P_LKRG_DEBUG_RULE(p_ed_pcfi_validate_sp),
+
+   { 0, NULL }
+};
+
+void __cyg_profile_func_enter(void *func, void *caller) {
+
+   struct p_addr_name *it;
+
+   for (it = p_addr_name_array; it->name != NULL; it++) {
+      if (it->addr == (uintptr_t)func) {
+         p_debug_log(P_LKRG_STRONG_DBG,
+            "Entering function <%s>\n", it->name);
+         break;
+      }
+   }
+}
+
+void __cyg_profile_func_exit(void *func, void *caller) {
+
+   struct p_addr_name *it;
+
+   for (it = p_addr_name_array; it->name != NULL; it++) {
+      if (it->addr == (uintptr_t)func) {
+         p_debug_log(P_LKRG_STRONG_DBG,
+            "Leaving function <%s>\n", it->name);
+		   break;
+      }
+   }
+}
+#endif /* P_LKRG_DEBUG_BUILD */

--- a/src/modules/self-defense/hiding/p_hiding.c
+++ b/src/modules/self-defense/hiding/p_hiding.c
@@ -26,14 +26,10 @@ struct module_notes_attrs *p_find_notes_attrs;
 
 void p_hide_itself(void) {
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_hide_itself>\n");
-
    if (P_CTRL(p_hide_lkrg)) {
       p_print_log(P_LKRG_WARN,
              "Module is already hidden!\n");
-      goto p_hide_itself_out;
+      return;
    }
 
 /*
@@ -70,14 +66,6 @@ void p_hide_itself(void) {
    spin_unlock(&p_db_lock);
    /* Release the 'module_mutex' */
    mutex_unlock(&module_mutex);
-
-p_hide_itself_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_hide_itself>\n");
-
-   return;
 }
 
 #ifdef P_LKRG_UNHIDE
@@ -88,14 +76,10 @@ void p_unhide_itself(void) {
    struct kset       *p_tmp_kset   = p_tmp_mod->mkobj.kobj.kset;
    struct kobj_type  *p_tmp_ktype  = p_tmp_mod->mkobj.kobj.ktype;
 
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_unhide_itself>\n");
-
    if (!P_CTRL(p_hide_lkrg)) {
       p_print_log(P_LKRG_WARN,
              "Module is already unhidden (visible)!\n");
-      goto p_unhide_itself_out;
+      return;
    }
 
    /* We are heavily consuming module list here - take 'module_mutex' */
@@ -126,13 +110,5 @@ void p_unhide_itself(void) {
    spin_unlock(&p_db_lock);
    /* Release the 'module_mutex' */
    mutex_unlock(&module_mutex);
-
-p_unhide_itself_out:
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_unhide_itself>\n");
-
-   return;
 }
 #endif

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -86,16 +86,12 @@ p_ro_page p_ro __p_lkrg_read_only = {
 };
 
 
-void p_init_page_attr(void) {
+static void p_init_page_attr(void) {
 
    unsigned long *p_long_tmp = 0x0;
 #if !defined(CONFIG_ARM)
    unsigned long p_long_offset = PAGE_SIZE/sizeof(p_long_tmp); // On purpose sizeof pointer
 #endif
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_init_page_attr>\n");
 
    p_long_tmp = (unsigned long *)P_CTRL_ADDR;
 
@@ -148,23 +144,14 @@ void p_init_page_attr(void) {
                   *(p_long_tmp+3*p_long_offset));
    }
 #endif
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_init_page_attr>\n");
-
 }
 
-void p_uninit_page_attr(void) {
+static void p_uninit_page_attr(void) {
 
    unsigned long *p_long_tmp = 0x0;
 #if !defined(CONFIG_ARM)
    unsigned long p_long_offset = PAGE_SIZE/sizeof(p_long_tmp); // On purpose sizeof pointer
 #endif
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Entering function <p_uninit_page_attr>\n");
 
    if (p_attr_init) {
       p_long_tmp = (unsigned long *)P_CTRL_ADDR;
@@ -194,11 +181,6 @@ void p_uninit_page_attr(void) {
    }
 
    p_attr_init ^= p_attr_init;
-
-// STRONG_DEBUG
-   p_debug_log(P_LKRG_STRONG_DBG,
-          "Leaving function <p_uninit_page_attr>\n");
-
 }
 
 void p_parse_module_params(void) {


### PR DESCRIPTION
For know we will use instrumentation function to log the entry and return of the
function. This reduce the size of code for over 10%.

Signed-off-by: Mariusz Zaborski <oshogbo@vexillium.org>