### PR TITLE
Fix building on Linux 5.9

### DIFF
--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -65,7 +65,11 @@ int p_arch_jump_label_transform_entry(struct kretprobe_instance *p_ri, struct pt
        * OK, *_JUMP_LABEL tries to modify kernel core .text section
        */
       p_db.p_jump_label.p_state = P_JUMP_LABEL_CORE_TEXT;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+   } else if ( (p_module = P_SYM(p_module_text_address)(p_addr)) != NULL) {
+#else
    } else if ( (p_module = __module_text_address(p_addr)) != NULL) {
+#endif
       /*
        * OK, *_JUMP_LABEL tries to modify some module's .text section
        */

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -115,7 +115,11 @@ int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri, struct 
 
          p_text++;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+      } else if ( (p_module = P_SYM(p_module_text_address)(p_jl_batch_addr[p_cnt])) != NULL) {
+#else
       } else if ( (p_module = __module_text_address(p_jl_batch_addr[p_cnt])) != NULL) {
+#endif
 
          for (p_tmp = 0x0; p_tmp < p_db.p_module_list_nr; p_tmp++) {
             if (p_db.p_module_list_array[p_tmp].p_mod == p_module) {

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -507,7 +507,11 @@ void p_dump_seccomp(struct p_seccomp *p_sec, struct task_struct *p_task) {
    else
       p_sec->flag = 0x0;
    p_sec->flag_sync_thread = 0x0;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+   P_SYM(p_put_seccomp_filter)(p_task->seccomp.filter);
+#else
    P_SYM(p_put_seccomp_filter)(p_task);
+#endif
 
 }
 
@@ -1219,7 +1223,11 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
                                   (unsigned long)p_current->seccomp.filter);
          p_ret++;
       }
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+      P_SYM(p_put_seccomp_filter)(p_current->seccomp.filter);
+#else
       P_SYM(p_put_seccomp_filter)(p_current);
+#endif
    }
 
    /* Release reference to cred */
@@ -2043,7 +2051,11 @@ int p_exploit_detection_init(void) {
       goto p_exploit_detection_init_out;
    }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+   P_SYM(p_put_seccomp_filter) = (void (*)(struct seccomp_filter *))P_SYM(p_kallsyms_lookup_name)("__put_seccomp_filter");
+#else
    P_SYM(p_put_seccomp_filter) = (void (*)(struct task_struct *))P_SYM(p_kallsyms_lookup_name)("put_seccomp_filter");
+#endif
 
    if (!P_SYM(p_put_seccomp_filter)) {
       p_print_log(P_LKRG_ERR,

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -165,7 +165,7 @@ int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs 
 
    if (!p_umh_allowed) {
 p_call_usermodehelper_entry_not_allowed:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0)
       if (!strcmp("none",p_subproc->path) && p_subproc->file) {
          p_print_log(P_LKRG_ERR,
                 "<Exploit Detection> UMH is executing file from memory...\n");
@@ -237,7 +237,7 @@ p_call_usermodehelper_entry_not_allowed:
               break;
 
          }
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0)
       }
 #endif
    }

--- a/src/modules/kmod/p_kmod.c
+++ b/src/modules/kmod/p_kmod.c
@@ -251,8 +251,13 @@ unsigned int p_count_modules_from_sysfs_kobj(void) {
    spin_lock(&p_kset->list_lock);
    list_for_each_entry_safe(p_kobj, p_tmp_safe, &p_kset->list, entry) {
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+      if (!P_SYM(p_module_address)((unsigned long)p_kobj))
+         continue;
+#else
       if (!__module_address((unsigned long)p_kobj))
          continue;
+#endif
 
       if (!p_kobj->state_initialized || !p_kobj->state_in_sysfs) {
          /* Weirdo state :( */
@@ -320,8 +325,13 @@ int p_list_from_sysfs_kobj(p_module_kobj_mem *p_arg) {
    spin_lock(&p_kset->list_lock);
    list_for_each_entry_safe(p_kobj, p_tmp_safe, &p_kset->list, entry) {
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+      if (!P_SYM(p_module_address)((unsigned long)p_kobj))
+         continue;
+#else
       if (!__module_address((unsigned long)p_kobj))
          continue;
+#endif
 
       if (!p_kobj->state_initialized || !p_kobj->state_in_sysfs) {
          /* Weirdo state :( */

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -439,6 +439,26 @@ static int __init p_lkrg_register(void) {
    }
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+   P_SYM(p_module_address) = (struct module* (*)(unsigned long))P_SYM(p_kallsyms_lookup_name)("__module_address");
+
+   if (!P_SYM(p_module_address)) {
+      p_print_log(P_LKRG_ERR,
+             "ERROR: Can't find '__module_address' function :( Exiting...\n");
+      p_ret = P_LKRG_GENERAL_ERROR;
+      goto p_main_error;
+   }
+
+   P_SYM(p_module_text_address) = (struct module* (*)(unsigned long))P_SYM(p_kallsyms_lookup_name)("__module_text_address");
+
+   if (!P_SYM(p_module_text_address)) {
+      p_print_log(P_LKRG_ERR,
+             "ERROR: Can't find '__module_text_address' function :( Exiting...\n");
+      p_ret = P_LKRG_GENERAL_ERROR;
+      goto p_main_error;
+   }
+#endif
+
    // Freeze all non-kernel processes
    while (P_SYM(p_freeze_processes)())
       schedule();

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -179,6 +179,10 @@ typedef struct _p_lkrg_global_symbols_structure {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
    void (*p_native_write_cr4)(unsigned long p_val);
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+   struct module* (*p_module_address)(unsigned long p_val);
+   struct module* (*p_module_text_address)(unsigned long p_val);
+#endif
    int (*p_kallsyms_on_each_symbol)(int (*)(void *, const char *, struct module *, unsigned long), void *);
    struct module *p_find_me;
 

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -146,7 +146,11 @@ typedef struct _p_lkrg_global_symbols_structure {
 #endif
    int (*p_is_kernel_text_address)(unsigned long p_addr);
    void (*p_get_seccomp_filter)(struct task_struct *p_task);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+   void (*p_put_seccomp_filter)(struct seccomp_filter *p_filter);
+#else
    void (*p_put_seccomp_filter)(struct task_struct *p_task);
+#endif
 #ifdef CONFIG_SECURITY_SELINUX
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 0)
    int *p_selinux_enabled;


### PR DESCRIPTION
1. `file` is no longer a field in the `subprocess_info` struct, so we just don't use it.
2. `__module_address` and `__module_text_address` are no longer exported, so we need to resolve these symbols at runtime.
3. `put_seccomp_filter` has been removed, so we need to use `__put_seccomp_filter` instead and modify calls to this function.

My understanding on LKRG's code is very limited, so please check this for errors. With these fixes I managed to build LKRG against 5.9.0 and it reports successful initialization when it is loaded.