### PR TITLE
umh: Kill process using the proper SIGKILL signal.

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -357,6 +357,12 @@ static inline unsigned long get_random_long(void) {
 }
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#define p_force_sig(sig) force_sig((sig))
+#else
+#define p_force_sig(sig) force_sig((sig), current)
+#endif
+
 /* Task integrity lock API */
 static inline void p_tasks_read_lock_raw(rwlock_t *p_arg) {
 

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -52,7 +52,6 @@
    }
 
 char p_call_usermodehelper_kretprobe_state = 0;
-static DEFINE_SPINLOCK(p_umh_attr_lock);
 
 static struct kretprobe p_call_usermodehelper_kretprobe = {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
@@ -170,51 +169,10 @@ p_call_usermodehelper_entry_not_allowed:
 
             /* Prevent execution */
             case 1:
-
-              i = 0;
-              while (p_subproc->path[i] == '/')
-                 i++;
-
-              if (i > 1 && !p_subproc->path[i]) { /* at least 2 slashes and nothing else */
-                 p_print_log(P_LKRG_CRIT,
-                        "Blocked usermodehelper execution of a previously blocked pathname\n");
-              } else {
-                 spin_lock(&p_umh_attr_lock);
-                 p_print_log(P_LKRG_CRIT,
-                        "Blocked usermodehelper execution of [%s]\n",
-                        p_subproc->path);
-                 do {
-                    int p_writable = 1;
-                    unsigned long p_addr = (unsigned long)p_subproc->path;
-                    spinlock_t *p_ptl;
-                    pte_t *p_pte;
-                    struct mm_struct *p_mm = (current->mm) ? current->mm : current->active_mm;
-                    pmd_t *p_pmd = P_SYM(p_mm_find_pmd)(p_mm, p_addr);
-
-                    /*
-                     * If we can't find PMD, we assume that the page is writable.
-                     * The main reason behind that is because we don't know what
-                     * are the current attributes. If we don't know them, we can't
-                     * safely modify it because we won't be able to restore them.
-                     */
-                    if (p_pmd) {
-                       p_pte = pte_offset_map_lock(p_mm, p_pmd, p_addr, &p_ptl);
-                       if (!pte_write(*p_pte)) {
-                          p_writable = 0;
-                       }
-                       pte_unmap_unlock(p_pte, p_ptl);
-                    }
-
-                    if (p_writable) {
-                       memset((char *)p_addr, '/', strlen(p_subproc->path));
-                    } else {
-                       p_set_memory_rw(p_addr & PAGE_MASK,1);
-                       memset((char *)p_addr, '/', strlen(p_subproc->path));
-                       p_set_memory_ro(p_addr & PAGE_MASK,1);
-                    }
-                 } while(0);
-                 spin_unlock(&p_umh_attr_lock);
-              }
+              p_print_log(P_LKRG_CRIT,
+                     "Blocked usermodehelper execution of [%s]\n",
+                     p_subproc->path);
+              p_force_sig(SIGKILL);
               break;
 
             /* Log only */


### PR DESCRIPTION
When we detect an invalid binary, we forbid it execution by changing the
subprocess execution path with slashes.
On some kernels, this may not work because we have to map the memory page as
writable. At this moment of execution, we can stop executing the process using
the froce_sig to send signals. The send_sig_info will not arrive at the right
time.

This should fix [Issue 4](https://github.com/openwall/lkrg/issues/4)