### PR TITLE
UMH: Allow all the pathnames listed in p_umh_global

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1830,8 +1830,6 @@ int p_exploit_detection_init(void) {
    int p_ret;
    const struct p_functions_hooks *p_fh_it;
 
-   p_usermodehelper_init();
-
    p_global_off_cookie = (unsigned long)get_random_long();
    p_global_cnt_cookie = (unsigned long)get_random_long();
 

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -21,37 +21,6 @@
 
 #include "../../../../p_lkrg_main.h"
 
-#define UMH_LIST                                                \
-   {                                                            \
-       UMH_UNIFIFW                                              \
-       UMH_LNET_UPCALL                                          \
-       UMH_OSD_LOGIN                                            \
-       { "/bin/false", false },                                 \
-       { "/bin/true", false },                                  \
-       { "/etc/acpi/events/RadioPower.sh", false },             \
-       { "/etc/acpi/wireless-rtl-ac-dc-power.sh", false },      \
-       { "/lib/systemd/systemd-cgroups-agent", false },         \
-       { "/sbin/bridge-stp", false },                           \
-       { "/sbin/critical_overtemp", false },                    \
-       { "/sbin/drbdadm", false },                              \
-       { "/sbin/hotplug", false },                              \
-       { "/sbin/modprobe", false },                             \
-       { "/sbin/nfs_cache_getent", false },                     \
-       { "/sbin/nfsd-recall-failed", false },                   \
-       { "/sbin/nfsdcltrack", false },                          \
-       { "/sbin/ocfs2_hb_ctl", false },                         \
-       { "/sbin/pnpbios", false },                              \
-       { "/sbin/poweroff", false },                             \
-       { "/sbin/request-key", false },                          \
-       { "/sbin/tomoyo-init", false },                          \
-       { "/sbin/v86d", false },                                 \
-       { "/system/bin/start", false },                          \
-       { "/usr/lib/systemd/systemd-cgroups-agent", false },     \
-       { "/usr/lib/systemd/systemd-coredump", false },          \
-       { "/usr/sbin/eppfpga", false },                          \
-       { "/usr/share/apport/apport", false }                    \
-   }
-
 char p_call_usermodehelper_kretprobe_state = 0;
 
 static struct kretprobe p_call_usermodehelper_kretprobe = {
@@ -67,46 +36,35 @@ static struct kretprobe p_call_usermodehelper_kretprobe = {
     .maxactive = 40,
 };
 
-struct p_umh_path {
-   const char *p_path;
-   bool p_enabled;
-} p_umh_global[] = UMH_LIST;
-
-static int p_check_if_file_exists(const char *p_arg) {
-
-   struct path p_path;
-
-   p_debug_log(P_LKRG_DBG,
-          "Trying to resolve [%s]\n",p_arg);
-
-   if (kern_path(p_arg, LOOKUP_FOLLOW, &p_path) != P_LKRG_SUCCESS) {
-      p_print_log(P_LKRG_INFO,
-             "[kern_path] Can't resolve filename: [%s]\n",p_arg);
-      return P_LKRG_GENERAL_ERROR;
-   }
-
-   path_put(&p_path);
-
-   return P_LKRG_SUCCESS;
-}
-
-void p_usermodehelper_init(void) {
-
-   size_t p_allowed, i;
-
-   for (p_allowed = 0, i = 0; i < nitems(p_umh_global); i++) {
-      if (!p_check_if_file_exists(p_umh_global[i].p_path)) {
-         p_umh_global[i].p_enabled = true;
-         p_print_log(P_LKRG_INFO,
-                "Allowing: [%s]\n", p_umh_global[i].p_path);
-         p_allowed++;
-      }
-   }
-
-   p_print_log(P_LKRG_WARN,
-          "%zu/%zu UMH paths are allowed...\n",
-          p_allowed, nitems(p_umh_global));
-}
+static const char * const p_umh_global[] = {
+   UMH_UNIFIFW
+   UMH_LNET_UPCALL
+   UMH_OSD_LOGIN
+   "/bin/false",
+   "/bin/true",
+   "/etc/acpi/events/RadioPower.sh",
+   "/etc/acpi/wireless-rtl-ac-dc-power.sh",
+   "/lib/systemd/systemd-cgroups-agent",
+   "/sbin/bridge-stp",
+   "/sbin/critical_overtemp",
+   "/sbin/drbdadm",
+   "/sbin/hotplug",
+   "/sbin/modprobe",
+   "/sbin/nfs_cache_getent",
+   "/sbin/nfsd-recall-failed",
+   "/sbin/nfsdcltrack",
+   "/sbin/ocfs2_hb_ctl",
+   "/sbin/pnpbios",
+   "/sbin/poweroff",
+   "/sbin/request-key",
+   "/sbin/tomoyo-init",
+   "/sbin/v86d",
+   "/system/bin/start",
+   "/usr/lib/systemd/systemd-cgroups-agent",
+   "/usr/lib/systemd/systemd-coredump",
+   "/usr/sbin/eppfpga",
+   "/usr/share/apport/apport",
+};
 
 int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
@@ -114,7 +72,6 @@ int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs 
    struct subprocess_info *p_subproc = (struct subprocess_info *)p_regs_get_arg1(p_regs);
    unsigned char p_umh_allowed = 0;
    unsigned long p_flags;
-   struct p_umh_path p_umh_local[] = UMH_LIST;
    size_t i;
 
    p_ed_enforce_validation();
@@ -132,16 +89,10 @@ int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs 
    }
    p_tasks_write_unlock(&p_flags);
 
-   /*
-    * Make it harder for the attacker to change the allowed paths by
-    * relying on the local variable on the stack
-    */
    for (i = 0; i < nitems(p_umh_global); i++) {
-      if (p_umh_global[i].p_enabled) {
-         if (!strcmp(p_umh_local[i].p_path, p_subproc->path)) {
-            p_umh_allowed = 1;
-            break;
-         }
+      if (!strcmp(p_umh_global[i], p_subproc->path)) {
+         p_umh_allowed = 1;
+         break;
       }
    }
 

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
@@ -27,8 +27,6 @@ struct p_call_usermodehelper_data {
     ktime_t entry_stamp;
 };
 
-void p_usermodehelper_init(void);
-
 int p_call_usermodehelper_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_call_usermodehelper_hook(int p_isra);

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_usermode_kernel_dep.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_usermode_kernel_dep.h
@@ -23,17 +23,17 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,11,0)
  #ifdef ANDROID_BUILD
-   #define UMH_UNIFIFW          { "/system/bin/unififw", false },
+   #define UMH_UNIFIFW          "/system/bin/unififw",
  #else
-   #define UMH_UNIFIFW          { "/usr/sbin/unififw", false },
+   #define UMH_UNIFIFW          "/usr/sbin/unififw",
  #endif /* ANDROID_BUILD */
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(4,18,0)
-   #define UMH_LNET_UPCALL      { "/usr/lib/lustre/lnet_upcall", false },            \
-                                { "/usr/lib/lustre/lnet_debug_log_upcall", false },
+   #define UMH_LNET_UPCALL      "/usr/lib/lustre/lnet_upcall",           \
+                                "/usr/lib/lustre/lnet_debug_log_upcall",
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
-   #define UMH_OSD_LOGIN        { "/sbin/osd_login", false },
+   #define UMH_OSD_LOGIN        "/sbin/osd_login",
 #endif
 
 #ifndef UMH_UNIFIFW


### PR DESCRIPTION
UMH contains a list of files that are allowed to execute.
LKRG during the load checks if the file exists; if so, the file is added to
the whitelist. The umh_preexists_files allows controlling this check.
By disabling lkrg.umh_prexists_files sysctl, all the files from the
lists will be allowed no matter if they were created after LKRG was loaded.