### PR TITLE
Build LKRG in-tree using copy-builtin.sh

### DIFF
--- a/scripts/copy-builtin.sh
+++ b/scripts/copy-builtin.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+# Build simple variables
+KDIR="${KDIR:="/usr/src/linux"}"
+LDIR="$KDIR/security/lkrg"
+BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+SDIR="$BASEDIR/../src"
+COMMIT="LKRG in-tree @ $(git log|head -1|cut -d' ' -f2|cut -c 1-24)"
+# Build heredoc variables
+KCONFIG=$( cat <<EOC
+# SPDX-License-Identifier: GPL-2.0-only
+config SECURITY_LKRG
+	tristate "LKRG support"
+	depends on SECURITY
+	default m
+	help
+	  This selects LKRG - Linux Kernel Runtime Guard, which provides
+          integrity validation and anti-exploitation functions.
+
+	  If you are unsure how to answer this question, answer M.
+EOC
+)
+
+MAKEFILE=$(cat <<EOC
+# SPDX-License-Identifier: GPL-2.0-only
+
+obj-\$(CONFIG_SECURITY_LKRG) := p_lkrg.o
+$(awk '/^p_lkrg-objs/,/^$/' "$BASEDIR/../Makefile"|sed -e 's|src/||')
+ 
+EOC
+)
+
+MAKEADD=$(cat <<EOC
+
+# LKRG file list
+subdir-\$(CONFIG_SECURITY_LKRG)         += lkrg
+obj-\$(CONFIG_SECURITY_LKRG)            += lkrg/
+EOC
+)
+# Tell user what we're about to do
+echo "Copying $SDIR/* to $LDIR along with Kconfig:"
+echo "$KCONFIG"
+echo
+echo "and Makefile"
+echo "$MAKEFILE"
+echo "Commit msg: $COMMIT"
+echo "Ctrl+c to quit, any other key to continue"
+read CANCEL
+# Execute copy
+mkdir -p "$LDIR"
+echo "$KCONFIG" > "$LDIR/Kconfig"
+echo "$MAKEFILE" > "$LDIR/Makefile"
+pushd .
+cd "$SDIR"
+cp -a . "$LDIR/"
+cd "$KDIR"
+# Update sources for built-in usage
+sed -i '/source "security\/integrity\/Kconfig"/asource "security/lkrg/Kconfig"' security/Kconfig
+echo "$MAKEADD" >> security/Makefile
+# Commit the changes
+git add "security/lkrg"
+git commit -am "$COMMIT"
+popd


### PR DESCRIPTION
DKMS is not always desirable on a system which one intends to
harden from local attackers. The build-chain creates a wide local
attack surface and can be used to build kmode rootkits and other
fun toys for red team. There are also space, performance,
and security considerations such as leaving RANDSTRUCT seeds
around in headers which can be addressed by bringing the module
in with the kernel package.

In order to avoid this, and take advantage of pending advances
in LTO, KCFI, and other methods depending on or benefitting from
having all of the code available at initial compile/link-time, a
script has been added to update the desired kernel tree with the
LKRG source code and relevant Makefile and Kconfig directives.

Since LKRG is still in active development, this script pulls all
relevant content and the current commit hash to let the kernel
maintainers using it keep aware of how far they've fallen behind
and see if subsequent commits merit a rebuild of the in-tree code.

Testing:
 Build-tested against linux-hardened 5.4.83.a as module

TODO:
 Determine if CONFIG_KALLSYMS_ALL is required when building the
module with the rest of the kernel or linking it directly into the
kernel binary.
 Test linking the module directly into the kernel, test resulting
kernel stability, defensive functions, etc.
 Create and apply documentation diffs in the script to inform
users of relevant boot and runtime parameters, as well as where to
go for help and issue reports.
