### PR TITLE
In-tree: fix for 58b9ec06

### DIFF
--- a/scripts/copy-builtin.sh
+++ b/scripts/copy-builtin.sh
@@ -26,7 +26,7 @@ MAKEFILE=$(cat <<EOC
 # SPDX-License-Identifier: GPL-2.0-only
 
 obj-\$(CONFIG_SECURITY_LKRG) := p_lkrg.o
-$(awk '/^p_lkrg-objs/,/^$/' "$BASEDIR/../Makefile"|sed -e 's|src/||')
+$(awk '/^\$\(TARGET\)-objs/,/^$/' "$BASEDIR/../Makefile"|sed -e 's|src/||; s|$(TARGET)-objs|p_lkrg-objs|')
  
 EOC
 )


### PR DESCRIPTION
After 58b9ec06, the script which copies module files into the
kernel source tree does not properly capture the files to be built
into p_lkrg.o.
Fix the awk expression performing the capture to adjust for the
new `$(TARGET)-obj` syntax and sed in-place to restore the original
name for in-tree build.