### PR TITLE
p_cmp_creds considers sudo to be a privesc attack

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1226,55 +1226,55 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
 int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred, struct task_struct *p_current, char p_opt) {
 
    int p_ret = 0;
-
-   /* *UID */
-   if (!uid_eq(p_orig->uid, p_current_cred->uid)) {
-      if (p_opt) {
-         p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different UID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_uid(&p_orig->uid), p_get_uid(&p_current_cred->uid));
+   if (strcmp(p_current->comm, "sudo") != 0) {
+      /* *UID */
+      if (!uid_eq(p_orig->uid, p_current_cred->uid)) {
+         if (p_opt) {
+            p_print_log(P_LKRG_CRIT,
+               "<Exploit Detection> process[%d | %s] has different UID! %d vs %d\n",
+               task_pid_nr(p_current), p_current->comm,
+               p_get_uid(&p_orig->uid), p_get_uid(&p_current_cred->uid));
+         }
+         p_ret++;
       }
-      p_ret++;
-   }
 
-   if (!uid_eq(p_orig->euid, p_current_cred->euid)) {
-      if (p_opt) {
-         p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different EUID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_uid(&p_orig->euid), p_get_uid(&p_current_cred->euid));
+      if (!uid_eq(p_orig->euid, p_current_cred->euid)) {
+         if (p_opt) {
+            p_print_log(P_LKRG_CRIT,
+               "<Exploit Detection> process[%d | %s] has different EUID! %d vs %d\n",
+               task_pid_nr(p_current), p_current->comm,
+               p_get_uid(&p_orig->euid), p_get_uid(&p_current_cred->euid));
+         }
+         p_ret++;
       }
-      p_ret++;
-   }
 
-   if (!uid_eq(p_orig->suid, p_current_cred->suid)) {
-      if (p_opt) {
-         p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different SUID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_uid(&p_orig->suid), p_get_uid(&p_current_cred->suid));
+      if (!uid_eq(p_orig->suid, p_current_cred->suid)) {
+         if (p_opt) {
+            p_print_log(P_LKRG_CRIT,
+               "<Exploit Detection> process[%d | %s] has different SUID! %d vs %d\n",
+               task_pid_nr(p_current), p_current->comm,
+               p_get_uid(&p_orig->suid), p_get_uid(&p_current_cred->suid));
+         }
+         p_ret++;
       }
-      p_ret++;
-   }
 
-   if (!uid_eq(p_orig->fsuid, p_current_cred->fsuid)) {
-      if (p_opt) {
-         p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different FSUID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_uid(&p_orig->fsuid), p_get_uid(&p_current_cred->fsuid));
+      if (!uid_eq(p_orig->fsuid, p_current_cred->fsuid)) {
+         if (p_opt) {
+            p_print_log(P_LKRG_CRIT,
+               "<Exploit Detection> process[%d | %s] has different FSUID! %d vs %d\n",
+               task_pid_nr(p_current), p_current->comm,
+               p_get_uid(&p_orig->fsuid), p_get_uid(&p_current_cred->fsuid));
+         }
+         p_ret++;
       }
-      p_ret++;
    }
-
    /* *GID */
    if (!gid_eq(p_orig->gid, p_current_cred->gid)) {
       if (p_opt) {
          p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different GID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_gid(&p_orig->gid), p_get_gid(&p_current_cred->gid));
+            "<Exploit Detection> process[%d | %s] has different GID! %d vs %d\n",
+            task_pid_nr(p_current), p_current->comm,
+            p_get_gid(&p_orig->gid), p_get_gid(&p_current_cred->gid));
       }
       p_ret++;
    }
@@ -1282,9 +1282,9 @@ int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred, struct
    if (!gid_eq(p_orig->egid, p_current_cred->egid)) {
       if (p_opt) {
          p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different EGID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_gid(&p_orig->egid), p_get_gid(&p_current_cred->egid));
+            "<Exploit Detection> process[%d | %s] has different EGID! %d vs %d\n",
+            task_pid_nr(p_current), p_current->comm,
+            p_get_gid(&p_orig->egid), p_get_gid(&p_current_cred->egid));
       }
       p_ret++;
    }
@@ -1292,9 +1292,9 @@ int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred, struct
    if (!gid_eq(p_orig->sgid, p_current_cred->sgid)) {
       if (p_opt) {
          p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different SGID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_gid(&p_orig->sgid), p_get_gid(&p_current_cred->sgid));
+            "<Exploit Detection> process[%d | %s] has different SGID! %d vs %d\n",
+            task_pid_nr(p_current), p_current->comm,
+            p_get_gid(&p_orig->sgid), p_get_gid(&p_current_cred->sgid));
       }
       p_ret++;
    }
@@ -1302,9 +1302,9 @@ int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred, struct
    if (!gid_eq(p_orig->fsgid, p_current_cred->fsgid)) {
       if (p_opt) {
          p_print_log(P_LKRG_CRIT,
-             "<Exploit Detection> process[%d | %s] has different FSGID! %d vs %d\n",
-             task_pid_nr(p_current), p_current->comm,
-             p_get_gid(&p_orig->fsgid), p_get_gid(&p_current_cred->fsgid));
+            "<Exploit Detection> process[%d | %s] has different FSGID! %d vs %d\n",
+            task_pid_nr(p_current), p_current->comm,
+            p_get_gid(&p_orig->fsgid), p_get_gid(&p_current_cred->fsgid));
       }
       p_ret++;
    }


### PR DESCRIPTION
Check whether the current process is "sudo" before running all of
the UID checks.

The stack traces produced priorto this commit show failures in the
EUID, SUID, and FSUID checks.

This may not be the best way to handle this as attackers running
privesc binaries just need to name them "sudo," but it does fix
the runtime issue of trying to use the legitimate sudo bin. A path
check for "/sbin/sudo" might be better, but distributions place
binaries in different places... Ideally we'd have some better way
to determine if the escalating binary is legitimate along with
coverage for other potentially impacted valid privesc methods.

### Description
Added a dirty hack to let me use `sudo` by checking the process
name for a `strcmp` against "sudo" - probably not the best way to
do this.

### How Has This Been Tested?
Built module against linux-hardened 5.4.89, loaded, ran sudo.

