### PR TITLE
CONFIG_PAX_RANDKSTACK ^ P_VERIFY_ADDR_LIMIT

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -218,7 +218,9 @@ struct p_task_off_debug {
 
 /* X86(-64)*/
 #if defined(CONFIG_X86) && LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
+#ifndef CONFIG_PAX_RANDKSTACK
  #define P_VERIFY_ADDR_LIMIT 1
+#endif
 /* ARM(64) */
 #elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
  #define P_VERIFY_ADDR_LIMIT 2


### PR DESCRIPTION
There are unofficial versions of RANDKSTACK patches floating about
the web, including in VMWare's PhotonOS.
The randomized stack addresses conflict with LKRG's ADDR_LIMIT
checks a la:
```
[  195.272462] [p_lkrg] <Exploit Detection> Detected ADDR_LIMIT
segment corruption! process[552 | sysctl] has different segment
address! [7ffffffff000 vs ffffffffffffffff]
```

Address this by ensuring that P_VERIFY_ADDR_LIMIT does not get
defined when CONFIG_PAX_RANDKSTACK is enabled.

This is a strange edge-case, and normally wouldn't be submitted as
a pull request to upstream projects, except that users seeking to
harden their kernels with public code are likely to run across
LKRG and some links to the PhotonOS patches or similar extracts
from Grsecurity's old patchsets. The commit is a no-op in 99% of
cases, but may result in one less bug report over the next decade.

### Description
Addresses a weird edge-case of using PhotonOS' old/unofficial RANDKSTACK implementation with LKRG

### How Has This Been Tested?
Built and run with a 5.4.89 kernel patched to use that RANDKSTACK implementation.

