### PR TITLE
copy-builtin: avoid errors when committing changes

### DIFF
--- a/scripts/copy-builtin.sh
+++ b/scripts/copy-builtin.sh
@@ -6,7 +6,9 @@ KDIR="${KDIR:="/usr/src/linux"}"
 LDIR="$KDIR/security/lkrg"
 BASEDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 SDIR="$BASEDIR/../src"
-COMMIT="LKRG in-tree @ $(git log|head -1|cut -d' ' -f2|cut -c 1-24)"
+if [ git rev-parse --git-dir &>/dev/null ]; then
+    COMMIT="LKRG in-tree @ $(git log|head -1|cut -d' ' -f2|cut -c 1-24)"
+fi
 # Build heredoc variables
 KCONFIG=$( cat <<EOC
 # SPDX-License-Identifier: GPL-2.0-only
@@ -44,7 +46,9 @@ echo "$KCONFIG"
 echo
 echo "and Makefile"
 echo "$MAKEFILE"
-echo "Commit msg: $COMMIT"
+if [ git rev-parse --git-dir &>/dev/null ]; then
+    echo "Commit msg: $COMMIT"
+fi
 echo "Ctrl+c to quit, any other key to continue"
 read CANCEL
 # Execute copy
@@ -59,6 +63,8 @@ cd "$KDIR"
 sed -i '/source "security\/integrity\/Kconfig"/asource "security/lkrg/Kconfig"' security/Kconfig
 echo "$MAKEADD" >> security/Makefile
 # Commit the changes
-git add "security/lkrg"
-git commit -am "$COMMIT"
+if [ git rev-parse --git-dir &>/dev/null ]; then
+    git add "security/lkrg"
+    git commit -am "$COMMIT"
+fi
 popd


### PR DESCRIPTION
If the source tree is not a git repository or git is not installed,
avoid throwing errors.

### Description
If the source tree to copy LKRG to as a built-in is not a git repository or git is not installed on the machine, errors are thrown although the install is a success. This commit checks for these prerequisites before trying to commit changes to a git repository.

### How Has This Been Tested?
The script was modified and run on both a machine with git installed but the source tree was not a git repository, as well as a machine where git was installed and the source tree was also a repository. In both cases no errors were thrown from the script and the copying of LKRG as a built-in was a success.

