### PR TITLE
Fix compilation fo kernel 5.11 on arm64

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -248,7 +248,7 @@ struct p_task_off_debug {
  #define P_VERIFY_ADDR_LIMIT 1
 #endif
 /* ARM(64) */
-#elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+#elif defined(CONFIG_ARM) || (defined(CONFIG_ARM64) && LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0))
  #define P_VERIFY_ADDR_LIMIT 2
 #endif
 


### PR DESCRIPTION
Since kernel commit 3d2403fd10a1dbb359b154af41ffed9f2a7520e8 there is no
more addr_limit on arm64.