### PR TITLE
mkosi and GA CI support for boot test on Ubuntus

### DIFF
--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -1,0 +1,47 @@
+name: mkosi boot (ubuntu)
+
+on: [push, pull_request]
+
+jobs:
+    mkosi-boot:
+        runs-on: ubuntu-20.04
+        strategy:
+            fail-fast: false
+            matrix:
+                release:
+                    - focal
+                    - groovy
+        steps:
+            - uses: actions/checkout@v2
+            - run: sudo apt-get update
+            - run: sudo apt-get install -y debootstrap qemu-system-x86 systemd-container expect
+            - name: Install mkosi from git
+              # Native focal package seems to be too old (v5) and not even
+              # able to build images properly.
+              run: |
+                  sudo python3 -m pip install git+https://github.com/systemd/mkosi.git
+                  echo /usr/local/bin >> $GITHUB_PATH
+
+            - name: Create bootable image using mkosi
+              run: sudo mkosi -r ${{ matrix.release }}
+
+            - name: Boot image using on qemu
+              run: |
+                  sudo expect <<- EOF | tr -d '\r' | tee boot.log
+                  proc abort {} { send_error "ABORT"; exit 1 }
+                  spawn mkosi qemu
+                  expect "Booting" { send "\r" }
+                  set timeout 120
+                  expect "login: " {} default abort
+                  set timeout 60
+                  expect "# " { send "systemctl poweroff\r" } default abort
+                  expect timeout abort eof { exit 0 }
+                  EOF
+              shell: bash -eo pipefail {0}
+
+            - name: Check boot.log for 'LKRG initialized successfully'
+              run: grep 'LKRG initialized successfully' boot.log
+            - name: Check that boot.log does not contain problems
+              run: egrep 'Panic|BUG:|WARNING:|Oops|Call Trace' boot.log && false || true
+
+# vim: sw=4

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ modules.order
 GPATH
 GRTAGS
 GTAGS
+
+# mkosi
+mkosi.cache
+image.raw*

--- a/mkosi.build
+++ b/mkosi.build
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+KERNELRELEASE=$(ls -d /lib/modules/*)
+KERNELRELEASE=${KERNELRELEASE##/lib/modules/}
+export KERNELRELEASE
+
+banner build
+set -x
+make -j$(nproc)
+install -Dpm 644 p_lkrg.ko $DESTDIR/lib/modules/$KERNELRELEASE/extra/p_lkrg.ko

--- a/mkosi.default
+++ b/mkosi.default
@@ -1,0 +1,34 @@
+[Distribution]
+Distribution=ubuntu
+# Linux version per release:
+#   focal  - v5.4
+#   groovy - v5.8
+Release=focal
+
+[Output]
+Bootable=yes
+# 'no_timer_check' is old workaround to intermittent apic kernel panic in qemu.
+KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1
+# Simplest way of installing initrd is without unified kernel image,
+# which requires bios (grub) boot.
+WithUnifiedKernelImages=no
+BootProtocols=bios
+
+[Partitions]
+RootSize=2G
+
+[Packages]
+BuildPackages=
+	diffutils
+	gcc
+	make
+	linux-virtual
+Packages=
+	sysvbanner
+
+[Host]
+QemuHeadless=yes
+
+[Validation]
+Password=
+Autologin=yes

--- a/mkosi.postinst
+++ b/mkosi.postinst
@@ -1,0 +1,18 @@
+#!/bin/bash -exu
+
+KERNELRELEASE=$(ls -d /lib/modules/*)
+KERNELRELEASE=${KERNELRELEASE##/lib/modules/}
+
+# mkosi phase 2
+#(We only support bios i.e. grub boot here).
+if test -x /usr/bin/dracut; then
+	banner postinst
+	# Register our module in kmod database.
+	depmod -a $KERNELRELEASE
+	# Install module into (and force load early in) initrd.
+	dracut --force --force-drivers p_lkrg /boot/initrd.img-$KERNELRELEASE $KERNELRELEASE
+	# Delete default cmdline which contains 'quiet splash' to see full boot log.
+	sed -i /GRUB_CMDLINE_LINUX_DEFAULT/d /etc/default/grub
+	update-grub
+fi
+exit 0


### PR DESCRIPTION
There are two commits:

```
Author: Vitaly Chikunov <vt@altlinux.org>
Date:   Mon Mar 29 06:37:51 2021 +0300

    Add mkosi support

    mkosi is systemd's boot test tool. This support is mainly for GA CI
    to implement full boot tests (on Ubuntu). But, this would be useful
    on it's own for experiments with lkrg on all mkosi supported distros.

    I support only bios (grub) BottProtocol without unified kernel.

    - .gitignore updated to exclude mkosi artifacts (otherwise they could
      recursively go into created image causing disk full error).
    - mkosi.default is mkosi config pre-confirured for ubuntu focal, you can
      overwrite this with command line options.
    - mkosi.build is script to build lkrg and install it into DESTDIR.
    - mkosi.postinst hook updates initrd to include and insmod lkrg and
      grub to remove 'quiet' cmdline option.

    Signed-off-by: Vitaly Chikunov <vt@altlinux.org>
```
I tested this only on Ubuntu focal (in Vagrant). But, this may work on other distributions where `mkosi` is supported (many, but not ALT).

```
Author: Vitaly Chikunov <vt@altlinux.org>
Date:   Mon Mar 29 06:46:52 2021 +0300

    CI: Boot test on GA using mkosi

    Use mkosi to test full system boot with LKRG module loaded early in
    initrd. mkosi creates system disk image (quite slow, 5 minutes for
    ubuntu focal in my tests, and size is 1.3G), builds lkrg there (using
    systemd-nspawn), and finally boots it in qemu. Then we grep boot.log
    for possible problems.

    Ubuntu is chosen, because it's native to GA. Only successful (for the
    test) releases are 'focal' and 'groovy'. It seems mkosi does not support
    'hirsute' (yet, failure installing packages into image). Also, 'xenial'
    does not build lkrg properly, but mkosi works good. Older Ubuntus seems
    to not have systemd, which is a hard mkosi requirement.

    Signed-off-by: Vitaly Chikunov <vt@altlinux.org>
```
Tested on different Ubuntu releases and only working are `focal` (with Linux v5.4), `groovy` (Linux v5.8), and `bionic` (with Linux v4.15, excluding the fact that LKRG does not build for it). I hope `hirsute` will work too as soon as it's released.
