### PR TITLE
CI: Boot test using Ubuntu mainline kernel build

### DIFF
--- a/.github/workflows/dpkg-i.sh
+++ b/.github/workflows/dpkg-i.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eux
+# Non-default mkosi.prepare script (--prepare-script=) to install
+# mainline kernel debs.
+# (It does have network and can run additional installs if needed.)
+
+banner "dpkg -i" >&2
+cd /root/src
+ls -l linux-*.deb
+dpkg -i linux-*.deb

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -1,20 +1,18 @@
-name: mkosi boot (ubuntu)
+name: mkosi boot (mainline)
 
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
+    schedule:
+        - cron: '0 10 * * *'
 
 jobs:
-    mkosi-boot:
+    mkosi-mainline:
         runs-on: ubuntu-20.04
-        strategy:
-            fail-fast: false
-            matrix:
-                release:
-                    - focal
-                    - groovy
         steps:
             - uses: actions/checkout@v2
             - run: sudo apt-get update
-            - run: sudo apt-get install -y debootstrap qemu-system-x86 systemd-container expect
+            - run: sudo apt-get install -y debootstrap qemu-system-x86 systemd-container expect sysvbanner
             - name: Install mkosi from git
               # Native focal package seems to be too old (v5) and not even
               # able to build images properly.
@@ -23,7 +21,9 @@ jobs:
                   echo /usr/local/bin >> $GITHUB_PATH
 
             - name: Create bootable image using mkosi
-              run: sudo mkosi -r ${{ matrix.release }} --cache=mkosi.cache
+              run: |
+                  .github/workflows/ubuntu-kernel-daily.sh
+                  sudo mkosi -r groovy -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
 
             - name: Boot image on qemu
               run: |
@@ -44,7 +44,7 @@ jobs:
                   grep 'Linux version' boot.log
                   grep 'LKRG initialized successfully' boot.log
             - name: Check that boot.log does not contain problems
-              run: egrep 'Panic|BUG:|WARNING:|Oops|Call Trace' boot.log && false || true
+              run: "! egrep 'Panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
             - name: Check that boot.log contains shutdown sequence
               run: |
                   grep 'Reached target.*Power-Off' boot.log

--- a/.github/workflows/ubuntu-kernel-daily.sh
+++ b/.github/workflows/ubuntu-kernel-daily.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Download daily Ubuntu mainline kernel from
+#   https://wiki.ubuntu.com/Kernel/MainlineBuilds
+#
+# Copyright (c) 2021 Vitaly Chikunov <vt@altlinux.org>.
+#
+
+baseurl="https://kernel.ubuntu.com/~kernel-ppa"
+for listurl in \
+	"$baseurl/mainline/daily/" \
+	"$baseurl/mainline/"
+do
+	echo >&2 "List $listurl"
+	curl -s "$listurl" \
+	| grep -Eio 'href="[^"]+"'   \
+	| grep -Eo '"[^"]+"'         \
+	| grep -Po '[v2][rc\.\d-]+'  \
+	| sort -Vr \
+	| while read subdir; do
+		url="$listurl$subdir/amd64/"
+		echo >&2 "Trying $url"
+		if page=$(curl -s --fail "$url"); then
+			banner $subdir >&2
+			# Show Ubuntu commit and build status.
+			curl --fail "$url/aggregate.yaml" || curl "$url/summary.yaml"
+			echo "$page" \
+			| grep -Eio 'href="[^"]+"' \
+			| grep -o "linux.*deb"     \
+			| grep -v "lowlatency"     \
+			| while read deb; do
+				if [ ! -e "$deb" ]; then
+					echo >&2 "Download $url$deb"
+					curl -O "$url$deb"
+				fi
+			done
+			# Signal success to upper shell.
+			exit 22
+		fi
+	done
+	# Exit if subshell succeeded.
+	[ $? -eq 22 ] && exit
+done

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ GRTAGS
 GTAGS
 
 # mkosi
+.mkosi-*
 mkosi.cache
 image.raw*

--- a/mkosi.build
+++ b/mkosi.build
@@ -1,10 +1,10 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
+# mkosi.build - Compile and install module into DESTDIR.
 
-KERNELRELEASE=$(ls -d /lib/modules/*)
+KERNELRELEASE=$(ls -d /lib/modules/* | sort -V | tail -1)
 KERNELRELEASE=${KERNELRELEASE##/lib/modules/}
 export KERNELRELEASE
 
-banner build
-set -x
+banner build $KERNELRELEASE >&2
 make -j$(nproc)
 install -Dpm 644 p_lkrg.ko $DESTDIR/lib/modules/$KERNELRELEASE/extra/p_lkrg.ko

--- a/mkosi.default
+++ b/mkosi.default
@@ -1,9 +1,11 @@
+# mkosi.default - Another way to run a test system with LKRG module.
+
 [Distribution]
 Distribution=ubuntu
 # Linux version per release:
 #   focal  - v5.4
 #   groovy - v5.8
-Release=focal
+Release=groovy
 
 [Output]
 Bootable=yes
@@ -15,16 +17,19 @@ WithUnifiedKernelImages=no
 BootProtocols=bios
 
 [Partitions]
-RootSize=2G
+# 2G was not enough for build with mainline kernels installs.
+RootSize=3G
 
 [Packages]
 BuildPackages=
 	diffutils
 	gcc
 	make
+	linux-base
 	linux-virtual
 Packages=
 	sysvbanner
+	kmod
 
 [Host]
 QemuHeadless=yes

--- a/mkosi.postinst
+++ b/mkosi.postinst
@@ -1,12 +1,14 @@
 #!/bin/bash -exu
+# mkosi.postinst - Install compiled module into initramfs and fix grub.
 
-KERNELRELEASE=$(ls -d /lib/modules/*)
+# Use kernel with highest version.
+KERNELRELEASE=$(ls -d /lib/modules/* | sort -V | tail -1)
 KERNELRELEASE=${KERNELRELEASE##/lib/modules/}
 
 # mkosi phase 2
 #(We only support bios i.e. grub boot here).
 if test -x /usr/bin/dracut; then
-	banner postinst
+	banner postinst >&2
 	# Register our module in kmod database.
 	depmod -a $KERNELRELEASE
 	# Install module into (and force load early in) initrd.


### PR DESCRIPTION
```
Ubuntu have daily builds of mainline kernels at
  https://wiki.ubuntu.com/Kernel/MainlineBuilds
They are built on groovy.
```
Example actions https://github.com/vt-alt/lkrg/actions

I decided to create 2 workflows (instead of single one with 3 element matrix, that I tried too), (**pros**) because -- this will allow to disable one of workflows (for example mainline one) from GA web UI; and allows to run mainline workflow also from cron schedule (daily). -- (**cons**) This will create two "lines" in Actions for every commit -- this is bad UI design, because single run is not grouped, but cant be helped (every other repo with complex workflows have that); and this is code duplication, but this is overall style of GA and cant be helped too.

I don't understand completely who will receive email notifications from cron builds - some documentation says that only me (last person who edited 'cron' line), which is not what is desiring.

Lets wait couple of days before merging (in case there is fixes).