### PR TITLE
CI: Improve mkosi testing (`-no-reboot`)

### DIFF
--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -28,8 +28,8 @@ jobs:
             - name: Boot image on qemu
               run: |
                   sudo expect <<- EOF | tr -d '\r' | tee boot.log
-                  proc abort {} { send_error "ABORT"; exit 1 }
-                  spawn mkosi qemu
+                  proc abort {} { send_error "ABORT\n"; exit 1 }
+                  spawn mkosi qemu -no-reboot
                   expect "Booting" { send "\r" }
                   set timeout 300
                   expect "login: " {} default abort

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -28,8 +28,8 @@ jobs:
             - name: Boot image on qemu
               run: |
                   sudo expect <<- EOF | tr -d '\r' | tee boot.log
-                  proc abort {} { send_error "ABORT"; exit 1 }
-                  spawn mkosi qemu
+                  proc abort {} { send_error "ABORT\n"; exit 1 }
+                  spawn mkosi qemu -no-reboot
                   expect "Booting" { send "\r" }
                   set timeout 300
                   expect "login: " {} default abort


### PR DESCRIPTION
- Add '\n' to `send_error' so the (timeout) error message is not lost.
  Otherwise, we see just "Error: Process completed with exit code 1."
- Add `-no-reboot' qemu option so the system does not cycle after first
  kernel panic (burying error message).

Improves on issues found in #62.