### PR TITLE
Enhance systemd service, introduce lkrg.conf

### DIFF
--- a/scripts/bootup/lkrg.conf
+++ b/scripts/bootup/lkrg.conf
@@ -1,0 +1,18 @@
+# lkrg.conf
+# Set LKRG sysctl settings here, so they won't be lost on service restart
+
+# Uncomment to block loading of kernel modules.
+#
+# This feature is meant primarily to prevent unintended user-triggered (or
+# attacker-triggered) auto-loading of maybe-vulnerable modules provided in a
+# distribution after all intended modules have already been loaded.  This
+# feature is not effective (nor is meant to be) against attackers who already
+# have root privileges and try to load a module explicitly (they could simply
+# flip this setting or even unload LKRG first).
+#
+# Please note that enabling this setting (too) early (e.g., using the module
+# parameter or /etc/sysctl.*) may cause the system to fail to complete bootup
+# (if required modules are still being loaded in later stages of bootup, which
+# varies between distributions and system configurations).
+#
+# lkrg.block_modules = 1

--- a/scripts/bootup/systemd/lkrg-systemd.sh
+++ b/scripts/bootup/systemd/lkrg-systemd.sh
@@ -6,6 +6,7 @@
 #  - Adam 'pi3' Zabrocki (http://pi3.com.pl)
 ##
 
+P_SYSCTL_DIR="/etc/sysctl.d"
 P_SYSTEMD_DIR="$(systemctl show -p UnitPath | cut -d " " -f5)"
 
 case "$P_SYSTEMD_DIR" in
@@ -32,6 +33,12 @@ if [ "$1" == "install" ]; then
 	systemctl enable lkrg.service
 	echo -e "       ${P_GREEN}To start ${P_YL}lkrg.service${P_GREEN} please use: ${P_YL}systemctl start lkrg${P_NC}"
     fi
+    if [ ! -e "$P_SYSCTL_DIR/lkrg.conf" ]; then
+	echo -e "       ${P_GREEN}Installing ${P_YL}lkrg.conf${P_GREEN} file under ${P_YL}$P_SYSCTL_DIR${P_GREEN} folder${P_NC}"
+	install -pm 644 -o root -g root scripts/bootup/lkrg.conf "$P_SYSCTL_DIR/lkrg.conf"
+    else
+	echo -e "       ${P_YL}lkrg.conf${P_GREEN} is already installed, skipping${P_NC}"
+    fi
 elif [ "$1" == "uninstall" ]; then
     echo -e "       ${P_GREEN}Stopping ${P_YL}lkrg.service${P_NC}"
     systemctl stop lkrg.service
@@ -39,6 +46,14 @@ elif [ "$1" == "uninstall" ]; then
     systemctl disable lkrg.service
     echo -e "       ${P_GREEN}Deleting ${P_YL}lkrg.service${P_GREEN} file from the ${P_YL}$P_SYSTEMD_DIR${P_GREEN} folder${P_NC}"
     rm "$P_SYSTEMD_DIR/lkrg.service"
+    if cmp -s "$P_SYSCTL_DIR/lkrg.conf" scripts/bootup/lkrg.conf; then
+        echo -e "       ${P_GREEN}Deleting unmodified ${P_YL}lkrg.conf${P_GREEN} file from the ${P_YL}$P_SYSCTL_DIR${P_GREEN} folder${P_NC}"
+        rm "$P_SYSCTL_DIR/lkrg.conf"
+    else
+        echo -e "       ${P_YL}$P_SYSCTL_DIR/lkrg.conf${P_GREEN} was modified, preserve it as ${P_YL}$P_SYSCTL_DIR/lkrg.conf.saved${P_NC}"
+        echo -e "       ${P_GREEN}If you do not need it anymore, delete it manually${P_NC}"
+        mv "$P_SYSCTL_DIR/lkrg.conf"{,.saved}
+    fi
 else
     echo -e "      ${P_RED}ERROR! Unknown option!${P_NC}"
     exit 1

--- a/scripts/bootup/systemd/lkrg.service
+++ b/scripts/bootup/systemd/lkrg.service
@@ -17,6 +17,7 @@ ConditionKernelCommandLine=!nolkrg
 [Service]
 Type=oneshot
 ExecStart=/sbin/modprobe -v p_lkrg
+ExecStartPost=/sbin/sysctl -p /etc/sysctl.d/lkrg.conf
 ExecStop=/sbin/modprobe -v -r p_lkrg
 RemainAfterExit=yes
 


### PR DESCRIPTION
lkrg-helper is aimed to help service manager to start and stop lkrg
service. Its main purpose to store and restore lkrg settings state
during service restart. It is designed to be service manager agnostic.

This commit also introduces a new semantic for systemctl reload that
restores lkrg default settings.

* libexec/lkrg-helper: New file.
* systemd/lkrg-systemd.sh: Install lkrg-helper.
* systemd/lkrg.service: Use lkrg-helper; add new semantic for reload
  that restores default lkrg settings.

### Description
<!--- Describe your changes -->

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

