### PR TITLE
CI: Update mkosi builds with 'hirsute'

### DIFF
--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -11,6 +11,7 @@ jobs:
                 release:
                     - focal
                     - groovy
+                    - hirsute
         steps:
             - uses: actions/checkout@v2
             - run: sudo apt-get update

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Create bootable image using mkosi
               run: |
                   .github/workflows/ubuntu-kernel-daily.sh
-                  sudo mkosi -r groovy -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
+                  sudo mkosi -r hirsute -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
 
             - name: Boot image on qemu
               run: |

--- a/mkosi.default
+++ b/mkosi.default
@@ -3,9 +3,10 @@
 [Distribution]
 Distribution=ubuntu
 # Linux version per release:
-#   focal  - v5.4
-#   groovy - v5.8
-Release=groovy
+#   focal   - v5.4
+#   groovy  - v5.8
+#   hirsute - v5.11
+Release=hirsute
 
 [Output]
 Bootable=yes


### PR DESCRIPTION
On 22 Apr 2021 Ubuntu released Hirsute Hippo (21.04) and started
building mainline kernels next day on it, causing mkosi builds fail
on 'groovy' with:

  dpkg: dependency problems prevent configuration of linux-headers-5.12.0-051200rc8daily20210423-generic:
   linux-headers-5.12.0-051200rc8daily20210423-generic depends on libc6 (>= 2.33); however:
    Version of libc6:amd64 on system is 2.32-0ubuntu3.

Also, update workflows and 'mkosi.default' to use 'hirsute'.

Tested, all green: https://github.com/vt-alt/lkrg/actions # 8 and 49.