### PR TITLE
CI: Fix download of the mainline kernel

### DIFF
--- a/.github/workflows/ubuntu-kernel-daily.sh
+++ b/.github/workflows/ubuntu-kernel-daily.sh
@@ -21,7 +21,8 @@ do
 	| while read subdir; do
 		url="$listurl$subdir/amd64/"
 		echo >&2 "Trying $url"
-		if page=$(curl -s --fail "$url"); then
+		if page=$(curl -s --fail "$url") &&
+		   echo "$page" | grep -q 'generic.*_amd64\.deb'; then
 			banner $subdir >&2
 			# Show Ubuntu commit and build status.
 			curl --fail "$url/aggregate.yaml" || curl "$url/summary.yaml"


### PR DESCRIPTION
Sometimes there are no kernel-ppa/mainline packages on the day even if
`amd64' dir exists, skip to the next day.

Should fix build error reported by @solardiz at https://github.com/openwall/lkrg/pull/83#issuecomment-840084388
