### PR TITLE
CI: Fix grepping for the kernel panics

### DIFF
--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -45,7 +45,7 @@ jobs:
                   grep 'Linux version' boot.log
                   grep 'LKRG initialized successfully' boot.log
             - name: Check that boot.log does not contain problems
-              run: egrep 'Panic|BUG:|WARNING:|Oops|Call Trace' boot.log && false || true
+              run: "! egrep 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
             - name: Check that boot.log contains shutdown sequence
               run: |
                   grep 'Reached target.*Power-Off' boot.log

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -44,7 +44,7 @@ jobs:
                   grep 'Linux version' boot.log
                   grep 'LKRG initialized successfully' boot.log
             - name: Check that boot.log does not contain problems
-              run: "! egrep 'Panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
+              run: "! egrep 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
             - name: Check that boot.log contains shutdown sequence
               run: |
                   grep 'Reached target.*Power-Off' boot.log


### PR DESCRIPTION
- Fix grep negation for the 'mkosi-boot' test.
- Also, change 'Panic' to 'Kernel panic' the way it should be.
