### PR TITLE
Add support for building LKRG via DKMS

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,11 @@
+PACKAGE_NAME="lkrg"
+PACKAGE_VERSION="0.9.1"
+#BUILT_MODULE_LOCATION[0]="output"
+BUILT_MODULE_NAME[0]="p_lkrg"
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_NAME[0]="p_lkrg"
+REMAKE_INITRD="no"
+AUTOINSTALL="yes"
+
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"


### PR DESCRIPTION
This simple `dkms.conf` file provides support for DKMS. To build LKRG using pure DKMS, you have to copy the LKRG source to the `/usr/src/lkrg-0.9.1/` and issue the following command:

```
# dkms install -m lkrg -v 0.9.1 -k 5.12.4-amd64

Creating symlink /var/lib/dkms/lkrg/0.9.1/source ->
                 /usr/src/lkrg-0.9.1

DKMS: add completed.

Kernel preparation unnecessary for this kernel.  Skipping...

Building module:
make -C /lib/modules/5.12.4-amd64/build M=/var/lib/dkms/lkrg/0.9.1/build clean
make: Entering directory '/usr/src/linux-headers-5.12.4-amd64'
make: Leaving directory '/usr/src/linux-headers-5.12.4-amd64'

{ make -j4 KERNELRELEASE=5.12.4-amd64 -C /lib/modules/5.12.4-amd64/build M=/var/lib/dkms/lkrg/0.9.1/build; } >> /var/lib/dkms/lkrg/0.9.1/build/make.log 2>&1


Running the post_build script:
Signing kernel_object: p_lkrg.ko
make -C /lib/modules/5.12.4-amd64/build M=/var/lib/dkms/lkrg/0.9.1/build clean
make: Entering directory '/usr/src/linux-headers-5.12.4-amd64'
  CLEAN   /var/lib/dkms/lkrg/0.9.1/build/Module.symvers
make: Leaving directory '/usr/src/linux-headers-5.12.4-amd64'


DKMS: build completed.

p_lkrg.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.12.4-amd64/updates/dkms/

do_depmod 5.12.4-amd64


DKMS: install completed.

# dkms status
lkrg, 0.9.1, 5.12.4-amd64, x86_64: installed
```

(Closes: #75)