### PR TITLE
Support unexporting of __module_address* by Linux 5.4.118+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+The following major changes have been made since LKRG 0.9.1:
+
+ *) Support new stable kernels 5.4.118+
+
+
 The following major changes have been made between LKRG 0.9.0 and 0.9.1:
 
  *) Support CONFIG_HAVE_STATIC_CALL on Linux 5.10+

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
@@ -84,7 +84,7 @@ notrace int p_ftrace_modify_all_code_entry(struct kretprobe_instance *p_ri, stru
 
          p_ftrace_tmp_text++;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
       } else if ( (p_module = P_SYM(p_module_text_address)(p_rec->ip)) != NULL) {
 #else
       } else if ( (p_module = __module_text_address(p_rec->ip)) != NULL) {

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -69,7 +69,7 @@ notrace int p_arch_jump_label_transform_entry(struct kretprobe_instance *p_ri, s
        * OK, *_JUMP_LABEL tries to modify kernel core .text section
        */
       p_db.p_jump_label.p_state = P_JUMP_LABEL_CORE_TEXT;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
    } else if ( (p_module = P_SYM(p_module_text_address)(p_addr)) != NULL) {
 #else
    } else if ( (p_module = __module_text_address(p_addr)) != NULL) {

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -113,7 +113,7 @@ notrace int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri,
 
          p_text++;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
       } else if ( (p_module = P_SYM(p_module_text_address)(p_jl_batch_addr[p_cnt])) != NULL) {
 #else
       } else if ( (p_module = __module_text_address(p_jl_batch_addr[p_cnt])) != NULL) {

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
@@ -67,7 +67,7 @@ notrace int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, 
 
          p_tracepoint_tmp_text++;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
       } else if ( (p_module1 = P_SYM(p_module_text_address)(p_tramp)) != NULL) {
 #else
       } else if ( (p_module1 = __module_text_address(p_tramp)) != NULL) {
@@ -101,7 +101,7 @@ notrace int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, 
 
          p_tracepoint_tmp_text++;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
       } else if ( (p_module2 = P_SYM(p_module_text_address)(p_site)) != NULL) {
 #else
       } else if ( (p_module2 = __module_text_address(p_site)) != NULL) {

--- a/src/modules/kmod/p_kmod.c
+++ b/src/modules/kmod/p_kmod.c
@@ -207,7 +207,7 @@ unsigned int p_count_modules_from_sysfs_kobj(void) {
    spin_lock(&p_kset->list_lock);
    list_for_each_entry_safe(p_kobj, p_tmp_safe, &p_kset->list, entry) {
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
       if (!P_SYM(p_module_address)((unsigned long)p_kobj))
          continue;
 #else
@@ -271,7 +271,7 @@ static int p_list_from_sysfs_kobj(p_module_kobj_mem *p_arg) {
    spin_lock(&p_kset->list_lock);
    list_for_each_entry_safe(p_kobj, p_tmp_safe, &p_kset->list, entry) {
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
       if (!P_SYM(p_module_address)((unsigned long)p_kobj))
          continue;
 #else

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -425,7 +425,7 @@ static int __init p_lkrg_register(void) {
  #endif
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
    P_SYM(p_module_address) = (struct module* (*)(unsigned long))P_SYM(p_kallsyms_lookup_name)("__module_address");
 
    if (!P_SYM(p_module_address)) {

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -217,7 +217,9 @@ typedef struct _p_lkrg_global_symbols_structure {
    void (*p_native_write_cr4)(unsigned long p_val);
  #endif
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0) || \
+ (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,118) && LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0))
+#define P_LKRG_UNEXPORTED_MODULE_ADDRESS
    struct module* (*p_module_address)(unsigned long p_val);
    struct module* (*p_module_text_address)(unsigned long p_val);
 #endif


### PR DESCRIPTION
This is supposed to fix #93, but is not tested yet.