### PR TITLE
Install systemd unit to /etc/systemd/system unconditionally

### DIFF
--- a/scripts/bootup/systemd/lkrg-systemd.sh
+++ b/scripts/bootup/systemd/lkrg-systemd.sh
@@ -7,11 +7,7 @@
 ##
 
 P_SYSCTL_DIR="/etc/sysctl.d"
-P_SYSTEMD_DIR="$(systemctl show -p UnitPath | cut -d " " -f5)"
-
-case "$P_SYSTEMD_DIR" in
-	\/run/*) P_SYSTEMD_DIR=/etc/systemd/system ;;
-esac
+P_SYSTEMD_DIR="/etc/systemd/system"
 
 
 P_RED='\033[0;31m'


### PR DESCRIPTION
### Description
The systemd install script attempts to enumerate the proper location to install the LKRG unit to, which in its current state may lead to inconsistencies. Instead, the unit should be installed into `/etc/systemd/system` unconditionally, as this is the standard location for user-installed system units.

### How Has This Been Tested?
Issued a `make install` and verified that the unit was installed to `/etc/systemd/system`.

Closes #95 