### PR TITLE
CI: Build on different OS using Docker containers

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,30 @@
+name: Multi-OS container builds
+on: [push, pull_request]
+
+jobs:
+    build:
+        runs-on: ubuntu-20.04
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - image: centos:7
+                      run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
+                    - image: centos:8
+                      run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
+                    - image: quay.io/centos/centos:stream8
+                      run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
+                    - image: fedora:latest
+                      run: dnf install -y kernel-devel kernel gcc make elfutils-libelf-devel
+                    - image: alt:sisyphus
+                      run: apt-get update; apt-get install -y kernel-headers-modules-un-def gcc make libelf-devel
+
+        container:
+            image: ${{ matrix.image }}
+
+        steps:
+            - uses: actions/checkout@v1
+            - run: ${{ matrix.run }}
+            - run: make -j$(nproc) KERNELRELEASE=$(cd /lib/modules; ls)
+
+# vim: sw=4


### PR DESCRIPTION
Test build on Fedora, CentOS, and ALT.

https://github.com/openwall/lkrg/pull/61#issuecomment-813011209
> I think we should keep Ubuntu, but also add perhaps CentOS 7 and 8. Instead of CentOS 8, it can be (and will eventually have to be) AlmaLinux or (later) RockyLinux. Can also have Fedora or CentOS Stream - would probably let us catch issues (typically back-ports that LKRG needs to adapt to) before they appear in a RHEL/CentOS/AlmaLinux/RockyLinux release.
