### PR TITLE
Fix LKRG builds on new kernels

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 The following major changes have been made since LKRG 0.9.1:
 
- *) Support new stable kernels 5.4.118+
+ *) Support new stable kernels 5.4.118+, 4.19.191+, 4.14.233+
  *) Support various CONFIG_SECCOMP configurations
 
 

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
@@ -84,11 +84,7 @@ notrace int p_ftrace_modify_all_code_entry(struct kretprobe_instance *p_ri, stru
 
          p_ftrace_tmp_text++;
 
-#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-      } else if ( (p_module = P_SYM(p_module_text_address)(p_rec->ip)) != NULL) {
-#else
-      } else if ( (p_module = __module_text_address(p_rec->ip)) != NULL) {
-#endif
+      } else if ( (p_module = LKRG_P_MODULE_TEXT_ADDRESS(p_rec->ip)) != NULL) {
          for (p_tmp = 0; p_tmp < p_db.p_module_list_nr; p_tmp++) {
             if (p_db.p_module_list_array[p_tmp].p_mod == p_module) {
                /*

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -75,11 +75,7 @@ notrace int p_arch_jump_label_transform_entry(struct kretprobe_instance *p_ri, s
        * OK, *_JUMP_LABEL tries to modify kernel core .text section
        */
       p_db.p_jump_label.p_state = P_JUMP_LABEL_CORE_TEXT;
-#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-   } else if ( (p_module = P_SYM(p_module_text_address)(p_addr)) != NULL) {
-#else
-   } else if ( (p_module = __module_text_address(p_addr)) != NULL) {
-#endif
+   } else if ( (p_module = LKRG_P_MODULE_TEXT_ADDRESS(p_addr)) != NULL) {
       /*
        * OK, *_JUMP_LABEL tries to modify some module's .text section
        */

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -119,11 +119,7 @@ notrace int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri,
 
          p_text++;
 
-#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-      } else if ( (p_module = P_SYM(p_module_text_address)(p_jl_batch_addr[p_cnt])) != NULL) {
-#else
-      } else if ( (p_module = __module_text_address(p_jl_batch_addr[p_cnt])) != NULL) {
-#endif
+      } else if ( (p_module = LKRG_P_MODULE_TEXT_ADDRESS(p_jl_batch_addr[p_cnt])) != NULL) {
 
          for (p_tmp = 0; p_tmp < p_db.p_module_list_nr; p_tmp++) {
             if (p_db.p_module_list_array[p_tmp].p_mod == p_module) {

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
@@ -76,11 +76,7 @@ notrace int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, 
 
          p_tracepoint_tmp_text++;
 
-#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-      } else if ( (p_module1 = P_SYM(p_module_text_address)(p_tramp)) != NULL) {
-#else
-      } else if ( (p_module1 = __module_text_address(p_tramp)) != NULL) {
-#endif
+      } else if ( (p_module1 = LKRG_P_MODULE_TEXT_ADDRESS(p_tramp)) != NULL) {
          if (p_module1->state == MODULE_STATE_LIVE) {
 
             for (p_tmp = 0; p_tmp < p_db.p_module_list_nr; p_tmp++) {
@@ -114,11 +110,7 @@ notrace int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, 
 
          p_tracepoint_tmp_text++;
 
-#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-      } else if ( (p_module2 = P_SYM(p_module_text_address)(p_site)) != NULL) {
-#else
-      } else if ( (p_module2 = __module_text_address(p_site)) != NULL) {
-#endif
+      } else if ( (p_module2 = LKRG_P_MODULE_TEXT_ADDRESS(p_site)) != NULL) {
          if (p_module2->state == MODULE_STATE_LIVE) {
 
             for (p_tmp = 0; p_tmp < p_db.p_module_list_nr; p_tmp++) {

--- a/src/modules/kmod/p_kmod.c
+++ b/src/modules/kmod/p_kmod.c
@@ -207,13 +207,8 @@ unsigned int p_count_modules_from_sysfs_kobj(void) {
    spin_lock(&p_kset->list_lock);
    list_for_each_entry_safe(p_kobj, p_tmp_safe, &p_kset->list, entry) {
 
-#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-      if (!P_SYM(p_module_address)((unsigned long)p_kobj))
+      if (!LKRG_P_MODULE_ADDRESS((unsigned long)p_kobj))
          continue;
-#else
-      if (!__module_address((unsigned long)p_kobj))
-         continue;
-#endif
 
       if (!p_kobj->state_initialized || !p_kobj->state_in_sysfs) {
          /* Weirdo state :( */
@@ -271,13 +266,8 @@ static int p_list_from_sysfs_kobj(p_module_kobj_mem *p_arg) {
    spin_lock(&p_kset->list_lock);
    list_for_each_entry_safe(p_kobj, p_tmp_safe, &p_kset->list, entry) {
 
-#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-      if (!P_SYM(p_module_address)((unsigned long)p_kobj))
+      if (!LKRG_P_MODULE_ADDRESS((unsigned long)p_kobj))
          continue;
-#else
-      if (!__module_address((unsigned long)p_kobj))
-         continue;
-#endif
 
       if (!p_kobj->state_initialized || !p_kobj->state_in_sysfs) {
          /* Weirdo state :( */

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -116,6 +116,13 @@
 #define P_SELINUX_VERIFY
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0) || \
+ (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,118) && LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)) || \
+ (LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,191) && LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0)) || \
+ (LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,233) && LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+#define P_LKRG_UNEXPORTED_MODULE_ADDRESS
+#endif
+
 #define nitems(val)      (sizeof(val) / sizeof(val[0]))
 
 typedef struct _p_lkrg_global_conf_structure {
@@ -219,9 +226,7 @@ typedef struct _p_lkrg_global_symbols_structure {
    void (*p_native_write_cr4)(unsigned long p_val);
  #endif
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0) || \
- (LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,118) && LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0))
-#define P_LKRG_UNEXPORTED_MODULE_ADDRESS
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
    struct module* (*p_module_address)(unsigned long p_val);
    struct module* (*p_module_text_address)(unsigned long p_val);
 #endif

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -242,6 +242,14 @@ typedef struct _p_lkrg_global_symbols_structure {
 
 } p_lkrg_global_syms;
 
+#ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
+#define LKRG_P_MODULE_ADDRESS(p_addr)      P_SYM(p_module_address)(p_addr)
+#define LKRG_P_MODULE_TEXT_ADDRESS(p_addr) P_SYM(p_module_text_address)(p_addr)
+#else
+#define LKRG_P_MODULE_ADDRESS(p_addr)      __module_address(p_addr)
+#define LKRG_P_MODULE_TEXT_ADDRESS(p_addr) __module_text_address(p_addr)
+#endif
+
 typedef struct _p_lkrg_critical_variables {
 
    unsigned long p_dummy1;


### PR DESCRIPTION
### Description
Deduplicate use of __module_text_address.
Add more kernels where the unexported __module_address.

### How Has This Been Tested?
Build and loaded on 5.8.0-45

This should solve #100 
