### PR TITLE
delete superfluous file debian/files

### DIFF
--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,0 @@
-lkrg_0.9.1-2_source.buildinfo kernel optional


### PR DESCRIPTION
Why?

* It's superfluous.
* I don't remember seeing it in other packages.
* Its content are versioned. Unnecessary maintenance overhead to keep updated.
* Its contents change during build using debuild.
* Its contents are autogenerated.
