### PR TITLE
add Documentation=https://www.openwall.com/lkrg/

### DIFF
--- a/scripts/bootup/systemd/lkrg.service
+++ b/scripts/bootup/systemd/lkrg.service
@@ -7,6 +7,7 @@
 
 [Unit]
 Description=Linux Kernel Runtime Guard
+Documentation=https://www.openwall.com/lkrg/
 DefaultDependencies=no
 After=systemd-modules-load.service
 Before=systemd-sysctl.service


### PR DESCRIPTION
To fix Debian lintian warning.

```
I: lkrg-systemd: systemd-service-file-missing-documentation-key lib/systemd/system/lkrg.service
N: 
N:    The systemd service file does not contain a Documentation key.
N:    
N:    Documentation for systemd service files can be automatically viewed
N:    using systemctl help servicename if this field is present.
N:    
N:    Refer to the systemd.unit(5) manual page for details.
N:    
N:    Severity: wishlist, Certainty: certain
N:    
N:    Check: systemd, Type: binary
N:
```