### PR TITLE
fix path to /etc/sysctl.d/30-lkrg-dkms.conf

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,9 +17,9 @@ override_dh_install:
 	dh_install -p lkrg-systemd scripts/bootup/systemd/lkrg.service lib/systemd/system
 	mkdir -p debian/tmp/etc/sysctl.d
 	mkdir -p debian/tmp/etc/modules-load.d
-	cp scripts/bootup/lkrg.conf debian/tmp/etc/sysctl.d/30-lkrg-dkms.conf
+	cp scripts/bootup/lkrg.conf debian/tmp/etc/sysctl.d/01-lkrg.conf
 	cp debian/lkrg-dkms.modules debian/tmp/etc/modules-load.d/lkrg-dkms.conf
-	dh_install -p lkrg-dkms    debian/tmp/etc/sysctl.d/30-lkrg-dkms.conf etc/sysctl.d
+	dh_install -p lkrg-dkms    debian/tmp/etc/sysctl.d/01-lkrg.conf etc/sysctl.d
 	dh_install -p lkrg-dkms    debian/tmp/etc/modules-load.d/lkrg-dkms.conf etc/modules-load.d
 
 override_dh_dkms:

--- a/scripts/bootup/systemd/lkrg-systemd.sh
+++ b/scripts/bootup/systemd/lkrg-systemd.sh
@@ -28,11 +28,11 @@ if [ "$1" == "install" ]; then
 		echo -e "       ${P_GREEN}To start ${P_YL}lkrg.service${P_GREEN} please use: ${P_YL}systemctl start lkrg${P_NC}"
 		echo -e "       ${P_GREEN}To enable ${P_YL}lkrg.service${P_GREEN} on bootup please use: ${P_YL}systemctl enable lkrg.service${P_NC}"
 	fi
-	if [ -e "$P_SYSCTL_DIR/lkrg.conf" ]; then
-		echo -e "       ${P_YL}lkrg.conf${P_GREEN} is already installed, skipping${P_NC}"
+	if [ -e "$P_SYSCTL_DIR/01-lkrg.conf" ]; then
+		echo -e "       ${P_YL}01-lkrg.conf${P_GREEN} is already installed, skipping${P_NC}"
 	else
-		echo -e "       ${P_GREEN}Installing ${P_YL}lkrg.conf${P_GREEN} file under ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
-		install -pm 644 -o root -g root scripts/bootup/lkrg.conf "$P_SYSCTL_DIR/lkrg.conf"
+		echo -e "       ${P_GREEN}Installing ${P_YL}01-lkrg.conf${P_GREEN} file under ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
+		install -pm 644 -o root -g root scripts/bootup/lkrg.conf "$P_SYSCTL_DIR/01-lkrg.conf"
 	fi
 elif [ "$1" == "uninstall" ]; then
 	echo -e "       ${P_GREEN}Stopping ${P_YL}lkrg.service${P_NC}"
@@ -41,13 +41,13 @@ elif [ "$1" == "uninstall" ]; then
 	systemctl disable lkrg.service
 	echo -e "       ${P_GREEN}Deleting ${P_YL}lkrg.service${P_GREEN} file from ${P_YL}$P_SYSTEMD_DIR${P_GREEN} directory${P_NC}"
 	rm "$P_SYSTEMD_DIR/lkrg.service"
-	if cmp -s "$P_SYSCTL_DIR/lkrg.conf" scripts/bootup/lkrg.conf; then
-		echo -e "       ${P_GREEN}Deleting unmodified ${P_YL}lkrg.conf${P_GREEN} file from ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
-		rm "$P_SYSCTL_DIR/lkrg.conf"
-	elif [ -e "$P_SYSCTL_DIR/lkrg.conf" ]; then
-		echo -e "       ${P_YL}$P_SYSCTL_DIR/lkrg.conf${P_GREEN} was modified, preserving it as ${P_YL}$P_SYSCTL_DIR/lkrg.conf.saved${P_NC}"
+	if cmp -s "$P_SYSCTL_DIR/01-lkrg.conf" scripts/bootup/lkrg.conf; then
+		echo -e "       ${P_GREEN}Deleting unmodified ${P_YL}01-lkrg.conf${P_GREEN} file from ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
+		rm "$P_SYSCTL_DIR/01-lkrg.conf"
+	elif [ -e "$P_SYSCTL_DIR/01-lkrg.conf" ]; then
+		echo -e "       ${P_YL}$P_SYSCTL_DIR/01-lkrg.conf${P_GREEN} was modified, preserving it as ${P_YL}$P_SYSCTL_DIR/01-lkrg.conf.saved${P_NC}"
 		echo -e "       ${P_GREEN}If you do not need it anymore, delete it manually${P_NC}"
-		mv "$P_SYSCTL_DIR/lkrg.conf"{,.saved}
+		mv "$P_SYSCTL_DIR/01-lkrg.conf"{,.saved}
 	fi
 else
 	echo -e "      ${P_RED}ERROR! Unknown option!${P_NC}"

--- a/scripts/bootup/systemd/lkrg.service
+++ b/scripts/bootup/systemd/lkrg.service
@@ -18,7 +18,7 @@ ConditionKernelCommandLine=!nolkrg
 [Service]
 Type=oneshot
 ExecStart=/sbin/modprobe -v p_lkrg
-ExecStartPost=/sbin/sysctl -p /etc/sysctl.d/lkrg.conf
+ExecStartPost=/sbin/sysctl -p /etc/sysctl.d/01-lkrg.conf
 ExecStop=/sbin/modprobe -v -r p_lkrg
 RemainAfterExit=yes
 


### PR DESCRIPTION
https://github.com/openwall/lkrg/blob/main/debian/rules#L22 install [`scripts/bootup/lkrg.conf`](https://github.com/openwall/lkrg/blob/main/scripts/bootup/lkrg.conf) it to `/etc/sysctl.d/30-lkrg-dkms.conf`.

(The prefix `30-lkrg` seems right for a `d.` directory, i.e. for `/etc/sysctl.d/`.)

Not to `/etc/sysctl.d/lkrg.conf` as referenced in [`scripts/bootup/systemd/lkrg.service`](https://github.com/openwall/lkrg/blob/main/scripts/bootup/systemd/lkrg.service).

So in order to fix the Debian package (make LKRG work after installation) some change is required.

Currently this issue is happening:

```
user@localhost:~$ sudo systemctl status lkrg
```
```
● lkrg.service - Linux Kernel Runtime Guard
   Loaded: loaded (/lib/systemd/system/lkrg.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Sun 2021-07-25 15:40:37 UTC; 4s ago
  Process: 5539 ExecStart=/sbin/modprobe -v p_lkrg (code=exited, status=0/SUCCESS)
  Process: 5540 ExecStartPost=/sbin/sysctl -p /etc/sysctl.d/lkrg.conf (code=exited, status=255/EXCEPTION)
 Main PID: 5539 (code=exited, status=0/SUCCESS)

Jul 25 15:40:37 localhost.localdomain systemd[1]: Starting Linux Kernel Runtime Guard...
Jul 25 15:40:37 localhost.localdomain sysctl[5540]: sysctl: cannot open "/etc/sysctl.d/lkrg.conf": No such file or directory
Jul 25 15:40:37 localhost.localdomain systemd[1]: lkrg.service: Control process exited, code=exited, status=255/EXCEPTION
Jul 25 15:40:37 localhost.localdomain systemd[1]: lkrg.service: Failed with result 'exit-code'.
Jul 25 15:40:37 localhost.localdomain systemd[1]: Failed to start Linux Kernel Runtime Guard.
```

Issue being `sysctl: cannot open "/etc/sysctl.d/lkrg.conf": No such file or directory`.