### PR TITLE
CI: Build mainline on Ubuntu impish

### DIFF
--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Create bootable image using mkosi
               run: |
                   .github/workflows/ubuntu-kernel-daily.sh
-                  sudo mkosi -r hirsute -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
+                  sudo mkosi -r impish -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
 
             - name: Boot image on qemu
               run: |


### PR DESCRIPTION
Mainline builds are broken since 2021-09-12 because 'mainline' dpkgs
are prepared on (and for) `impish` (next release) instead of `hirsute`.

Fixed build fails, but, it seems, with a good reason.

```
+ make -j2
make -C /lib/modules/5.15.0-051500rc4daily20211006-generic/build M=/root/src modules
make[1]: Entering directory '/usr/src/linux-headers-5.15.0-051500rc4daily20211006-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (Ubuntu 11.2.0-3ubuntu1) 11.2.0
  You are using:           gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0
  CC [M]  /root/src/src/modules/ksyms/p_resolve_ksym.o
  CC [M]  /root/src/src/modules/hashing/p_lkrg_fast_hash.o
  CC [M]  /root/src/src/modules/comm_channel/p_comm_channel.o
  CC [M]  /root/src/src/modules/integrity_timer/p_integrity_timer.o
/root/src/src/modules/integrity_timer/p_integrity_timer.c: In function 'p_check_integrity':
/root/src/src/modules/integrity_timer/p_integrity_timer.c:172:4: error: implicit declaration of function 'get_online_cpus'; did you mean 'get_online_mems'? [-Werror=implicit-function-declaration]
  172 |    get_online_cpus();
      |    ^~~~~~~~~~~~~~~
      |    get_online_mems
/root/src/src/modules/integrity_timer/p_integrity_timer.c:214:4: error: implicit declaration of function 'put_online_cpus'; did you mean 'num_online_cpus'? [-Werror=implicit-function-declaration]
  214 |    put_online_cpus();
      |    ^~~~~~~~~~~~~~~
      |    num_online_cpus
  CC [M]  /root/src/src/modules/kmod/p_kmod.o
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:277: /root/src/src/modules/integrity_timer/p_integrity_timer.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /root/src/src/modules/kmod/p_kmod.c:25:
/root/src/src/modules/kmod/p_kmod_notifier.c: In function 'p_module_event_notifier':
/root/src/src/modules/kmod/p_kmod_notifier.c:98:7: error: implicit declaration of function 'get_online_cpus'; did you mean 'get_online_mems'? [-Werror=implicit-function-declaration]
   98 |       get_online_cpus();
      |       ^~~~~~~~~~~~~~~
      |       get_online_mems
/root/src/src/modules/kmod/p_kmod_notifier.c:101:7: error: implicit declaration of function 'put_online_cpus'; did you mean 'num_online_cpus'? [-Werror=implicit-function-declaration]
  101 |       put_online_cpus();
      |       ^~~~~~~~~~~~~~~
      |       num_online_cpus
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:277: /root/src/src/modules/kmod/p_kmod.o] Error 1
make[1]: Leaving directory '/usr/src/linux-headers-5.15.0-051500rc4daily20211006-generic'
make[1]: *** [Makefile:1874: /root/src] Error 2
make: *** [Makefile:97: all] Error 2
```
