### PR TITLE
CI: Automatically detect Ubuntu release for mainline test

### DIFF
--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -20,10 +20,11 @@ jobs:
                   sudo python3 -m pip install git+https://github.com/systemd/mkosi.git
                   echo /usr/local/bin >> $GITHUB_PATH
 
+            - name: Download mainline kernel from Kernel PPA
+              run: .github/workflows/ubuntu-kernel-daily.sh
+
             - name: Create bootable image using mkosi
-              run: |
-                  .github/workflows/ubuntu-kernel-daily.sh
-                  sudo mkosi -r impish -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
+              run: sudo mkosi -r ${{ env.series }} -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
 
             - name: Boot image on qemu
               run: |

--- a/.github/workflows/ubuntu-kernel-daily.sh
+++ b/.github/workflows/ubuntu-kernel-daily.sh
@@ -25,7 +25,10 @@ do
 		   echo "$page" | grep -q 'generic.*_amd64\.deb'; then
 			banner $subdir >&2
 			# Show Ubuntu commit and build status.
-			curl --fail "$url/aggregate.yaml" || curl "$url/summary.yaml"
+			curl -so .yaml --fail "$url/aggregate.yaml" || \
+			curl -so .yaml "$url/summary.yaml"
+			cat .yaml
+			[ -v GITHUB_ENV ] && sed -n '/^series:/{s/:\s*/=/p;q}' .yaml >> $GITHUB_ENV
 			echo "$page" \
 			| grep -Eio 'href="[^"]+"' \
 			| grep -o "linux.*deb"     \


### PR DESCRIPTION
### Description
<!--- Describe your changes -->

`series' property in `aggregate.yaml` and `summary.yaml` seems to be
Ubuntu release name appropriate for their dpkgs.

Set it (for a next step) using technique described in
  https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-environment-variable

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
On my fork.