### PR TITLE
CI: Disable seccomp filter for docker build tests

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -21,6 +21,7 @@ jobs:
 
         container:
             image: ${{ matrix.image }}
+            options: --security-opt seccomp=unconfined
 
         steps:
             - uses: actions/checkout@v1


### PR DESCRIPTION
When target system updated to glibc-2.34 (as for ALT Linux) it starts
to use new syscall `clone3', which is not enabled in Docker seccomp
filter, causing run failures. GA issue [1].

Disable Docker seccomp filtering since we are in throwable virtual
environment anyway and don't need that protection.

Link: https://github.com/actions/virtual-environments/issues/3812 [1]
Fixes: https://github.com/openwall/lkrg/issues/121
