### PR TITLE
CI: Fix builds on newer mkosi (v10+)

### DIFF
--- a/mkosi.default
+++ b/mkosi.default
@@ -11,7 +11,7 @@ Release=hirsute
 [Output]
 Bootable=yes
 # 'no_timer_check' is old workaround to intermittent apic kernel panic in qemu.
-KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1
+KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1 ignore_loglevel
 # Simplest way of installing initrd is without unified kernel image,
 # which requires bios (grub) boot.
 WithUnifiedKernelImages=no


### PR DESCRIPTION
Mkosi authors decided to add `loglevel=4' to the kernel boot parameters
in systemd/mkosi@fac7bf9 ("Set loglevel to something sane when
--qemu-headless is set") this was breaking mkosi based tests.

Fixes: #126

### Description
<!--- Describe your changes -->

### How Has This Been Tested?
https://github.com/vt-alt/lkrg/actions/runs/1476463050
