### PR TITLE
Report unexpected off flag depths

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -817,11 +817,30 @@ static notrace void p_debug_off_flag_dump_ring_buffer(struct p_ed_process *p_sou
 }
 #endif
 
+static inline int p_off_depth(long *p_val) {
+
+   int p_depth = 0;
+
+   while (*p_val > p_global_cnt_cookie) {
+      *p_val -= p_global_cnt_cookie;
+      p_depth++;
+      if (unlikely(*p_val > (p_global_cnt_cookie << 3)))
+         break;
+   }
+
+   return p_depth;
+}
+
 static inline void p_ed_is_off_off(struct p_ed_process *p_source, long p_val, int *p_ret) {
 
    if (unlikely(p_val != p_global_cnt_cookie)) {
-      p_print_log(P_LOG_ALERT, "DETECT: Task: unexpected 'off' flag for pid %u, name %s",
-         p_source->p_ed_task.p_pid, p_source->p_ed_task.p_comm);
+      long p_val_remainder = p_val;
+      int p_depth = p_off_depth(&p_val_remainder);
+      if (p_val_remainder != p_global_cnt_cookie)
+         p_depth = p_val ? 0 : -1;
+      /* Depths -1 or 1+ are exact, 0 means non-multiple or out of range */
+      p_print_log(P_LOG_ALERT, "DETECT: Task: unexpected 'off' flag depth %d for pid %u, name %s",
+         p_depth, p_source->p_ed_task.p_pid, p_source->p_ed_task.p_comm);
 #ifdef P_LKRG_TASK_OFF_DEBUG
       p_print_log(P_LOG_WATCH, "'off' flag[0x%lx] (normalization via 0x%lx)",
          p_val, p_global_cnt_cookie);
@@ -844,11 +863,7 @@ static inline void p_validate_off_flag(struct p_ed_process *p_source, long p_val
    if (likely(p_val == p_global_cnt_cookie))
       return;
 
-   while (p_val > p_global_cnt_cookie) {
-      p_val -= p_global_cnt_cookie;
-      if (unlikely(p_val > (p_global_cnt_cookie << 3)))
-         break;
-   }
+   p_off_depth(&p_val);
 
    p_ed_is_off_off(p_source, p_val, p_ret);
 }


### PR DESCRIPTION
### Description

This is useful for debugging while hopefully not too revealing for attacks. (And the timing leaks are the same as what we already had anyway.)

Fixes #424

### How Has This Been Tested?

In my dev VM, including by forcing this code to run. Now testing in our CI.