### PR TITLE
Fix build for 6.19+

### DIFF
--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -26,7 +26,13 @@ static int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs
 
    p_ed_pcfi_cpu(0);
 
-   if (!in_irq() && p_is_ed_task(current)) {
+   if (
+#if !defined(in_hardirq) && defined(in_irq)
+       !in_irq()
+#else
+       !in_hardirq()
+#endif
+       && p_is_ed_task(current)) {
       /* Do not take ED lock */
       if ((p_tmp = ed_task_trylock_current())) {
          p_ed_validate_current(p_tmp);

--- a/src/modules/net/net.c
+++ b/src/modules/net/net.c
@@ -140,7 +140,13 @@ static void maybe_reconnect(void)
 	saddr.sin_family = AF_INET;
 	saddr.sin_port = htons(net_server_port);
 	saddr.sin_addr.s_addr = net_server_addr_n;
-	switch ((err = sk->ops->connect(sk, (struct sockaddr *)&saddr, sizeof(saddr), O_WRONLY))) {
+	switch ((err = sk->ops->connect(sk,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
+	    (struct sockaddr_unsized *)
+#else
+	    (struct sockaddr *)
+#endif
+	    &saddr, sizeof(saddr), O_WRONLY))) {
 	case 0:
 	case -EINPROGRESS:
 		break;


### PR DESCRIPTION
### Description

Cast to the new (struct sockaddr_unsized *) on 6.19+. Use in_hardirq() in preference of the obsolete in_irq().

Fixes #452

### How Has This Been Tested?

In our CI setup only so far.