### PR TITLE
CI: Fix fedora-mainline workflow

### DIFF
--- a/.github/workflows/fedora-mainline.yml
+++ b/.github/workflows/fedora-mainline.yml
@@ -19,6 +19,7 @@ jobs:
               run: |
                   echo "::group::Prepare Docker container for build"
                   docker run --name=fedora \
+                      --security-opt seccomp=unconfined \
                       -v ${{ github.workspace }}:/workspace \
                       -w /workspace fedora:rawhide bash -ex -c '
                           cat /etc/os-release


### PR DESCRIPTION
Docker blocks `open_tree` syscall with EPERM while installing kernel-core.

Fixes: https://github.com/lkrg-org/lkrg/issues/457

### Description
Disable seccomp filtering.

### How Has This Been Tested?
Partially.
