### PR TITLE
Verify newly loaded modules are persisted in the database

### DIFF
--- a/src/modules/integrity_timer/p_integrity_timer.c
+++ b/src/modules/integrity_timer/p_integrity_timer.c
@@ -963,7 +963,7 @@ void p_check_integrity(struct work_struct *p_work) {
 
    if (p_hack_check) {
       p_print_log(P_LOG_ALERT, "DETECT: Kernel: %u checksums changed unexpectedly", p_hack_check);
-      if (P_CTRL(p_kint_enforce >= 2)) {
+      if (P_CTRL(p_kint_enforce) >= 2) {
          // OK, we need to crash the kernel now
          p_panic("Kernel: %u checksums changed unexpectedly", p_hack_check);
       }

--- a/src/modules/kmod/p_kmod_notifier.c
+++ b/src/modules/kmod/p_kmod_notifier.c
@@ -29,6 +29,11 @@ static struct notifier_block p_module_block_notifier = {
 
 };
 
+static const char * const p_mod_strings[] = {
+                          "New module is LIVE",
+                          "New module is COMING",
+                          "Module is GOING AWAY",
+                          "New module is UNFORMED yet" };
 
 static int p_block_always(void) {
 
@@ -47,6 +52,46 @@ static void p_module_notifier_wrapper(unsigned long p_event, struct module *p_km
 
    return;
 }
+
+static inline void p_verify_added_module(struct module *p_kmod) {
+
+   unsigned int p_tmp;
+   unsigned int p_found_mod = 0;
+   unsigned int p_found_obj = 0;
+
+   for (p_tmp = 0; p_tmp < p_db.p_module_list_nr; p_tmp++)
+      if (p_db.p_module_list_array[p_tmp].p_mod == p_kmod)
+         p_found_mod = 1;
+
+   for (p_tmp = 0; p_tmp < p_db.p_module_kobj_nr; p_tmp++)
+      if (p_db.p_module_kobj_array[p_tmp].p_mod == p_kmod)
+         p_found_obj = 1;
+
+   if (!p_found_mod || !p_found_obj) {
+      p_print_log(P_LOG_ALERT, "DETECT: Newly loaded module entering LIVE state is hidden!");
+      /* Singularity rootkit is hooking print function
+       * and removes any messages containing "LKRG" string.
+       * Because of that, we are using here raw printk()
+       */
+      printk(KERN_CRIT "Hidden module:\n");
+      printk(KERN_CRIT "\tPointer to struct module: [0x%lx]\n", (unsigned long)p_kmod);
+      printk(KERN_CRIT "\tName: [%s]\n", p_kmod->name);
+      printk(KERN_CRIT "\tState: [%d: %s]\n", p_kmod->state,
+                                              (p_kmod->state > MODULE_STATE_UNFORMED) ?
+                                              "WRONG STATE VALUE" :
+                                              p_mod_strings[p_kmod->state]);
+      /* We can do more here, e.g.,
+       *  - dump the entire module
+       *  - calculate hash from .text and behave like AV?
+       *  - more...
+       */
+      if (P_CTRL(p_kint_enforce) >= 2) {
+         // OK, we need to crash the kernel now
+         p_panic("Kernel: Newly loaded module [name: %s] in LIVE state is hidden!", p_kmod->name);
+      }
+   }
+}
+
 
 #if P_OVL_OVERRIDE_SYNC_MODE
 static void p_verify_module_live(struct module *p_mod);
@@ -71,12 +116,6 @@ static void p_verify_module_going(struct module *p_mod);
 static int p_module_event_notifier(struct notifier_block *p_this, unsigned long p_event, void *p_kmod) {
 
    struct module *p_tmp = p_kmod;
-
-   static const char * const p_mod_strings[] = {
-                             "New module is LIVE",
-                             "New module is COMING",
-                             "Module is GOING AWAY",
-                             "New module is UNFORMED yet" };
 
 // STRONG_DEBUG
    p_debug_log(P_LOG_FLOOD,
@@ -219,6 +258,8 @@ static int p_module_event_notifier(struct notifier_block *p_this, unsigned long 
          while(p_kmod_hash(&p_db.p_module_list_nr,&p_db.p_module_list_array,
                            &p_db.p_module_kobj_nr,&p_db.p_module_kobj_array, 2) != P_LKRG_SUCCESS)
             schedule();
+
+         p_verify_added_module(p_module_activity_ptr);
 
          /* Update global module list/kobj hash */
          p_db.p_module_list_hash = p_lkrg_fast_hash((unsigned char *)p_db.p_module_list_array,


### PR DESCRIPTION
### Description
Detect cases where a malicious module hides itself during init()
by checking whether the notifier routine adds it to the database.
Part of #455.

### How Has This Been Tested?
Against Singularity module