### PR TITLE
Try harder at killing tasks

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -274,12 +274,12 @@ struct p_ed_global_variables {
 
 };
 
-static inline int p_kill_task_by_task(struct task_struct *p_task) {
+static inline void p_kill_task_by_task(struct task_struct *p_task) {
 
    p_print_log(P_LOG_ALERT, "BLOCK: Task: Killing pid %u, name %s",
                task_pid_nr(p_task), p_task->comm);
 
-   return send_sig_info(SIGKILL, SEND_SIG_PRIV, p_task);
+   send_sig_info(SIGKILL, SEND_SIG_PRIV, p_task);
 }
 
 #include "ed_task_tree.h"
@@ -374,7 +374,7 @@ static inline unsigned int p_is_ed_task(struct task_struct *p_task) {
    return p_task->mm && !is_global_init(p_task);
 }
 
-static inline int p_ed_kill_task(struct p_ed_process *p_source) {
+static inline void p_ed_kill_task(struct p_ed_process *p_source) {
 
    struct task_struct *p_task = p_source->p_ed_task.p_task;
 
@@ -401,11 +401,9 @@ static inline int p_ed_kill_task(struct p_ed_process *p_source) {
          break;
 
    }
-
-   return 0;
 }
 
-static inline int p_pcfi_kill_edp_or_task(struct p_ed_process *p_source, struct task_struct *p_task) {
+static inline void p_pcfi_kill_edp_or_task(struct p_ed_process *p_source, struct task_struct *p_task) {
 
    if (p_source)
       p_task = p_source->p_ed_task.p_task;
@@ -421,11 +419,12 @@ static inline int p_pcfi_kill_edp_or_task(struct p_ed_process *p_source, struct 
 
       /* Kill task */
       case 1:
-         if (!p_source)
-            return p_kill_task_by_task(p_task);
-
-         /* Zero kill_task_on_unlock to kill upon unlocking the ed task lock */
-         p_source->kill_task_on_unlock = 0;
+         if (p_source) {
+            /* Zero kill_task_on_unlock to kill upon unlocking the ed task lock */
+            p_source->kill_task_on_unlock = 0;
+         } else {
+            p_kill_task_by_task(p_task);
+         }
          break;
 
       /* Log */
@@ -435,13 +434,11 @@ static inline int p_pcfi_kill_edp_or_task(struct p_ed_process *p_source, struct 
          break;
 
    }
-
-   return 0;
 }
 
-static inline int p_pcfi_kill_ed_task(struct p_ed_process *p_source) {
+static inline void p_pcfi_kill_ed_task(struct p_ed_process *p_source) {
 
-   return p_pcfi_kill_edp_or_task(p_source, NULL);
+   p_pcfi_kill_edp_or_task(p_source, NULL);
 }
 
 /*

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -363,12 +363,6 @@ void p_debug_off_flag_override_off(struct p_ed_process *p_source, unsigned int p
 void p_debug_off_flag_override_on(struct p_ed_process *p_source, unsigned int p_id, struct pt_regs *p_regs);
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
-#define p_force_sig(sig) force_sig((sig))
-#else
-#define p_force_sig(sig) force_sig((sig), current)
-#endif
-
 static inline unsigned int p_is_ed_task(struct task_struct *p_task) {
 
    return p_task->mm && !is_global_init(p_task);

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -274,12 +274,16 @@ struct p_ed_global_variables {
 
 };
 
+static inline void p_crash_task_if_current(struct task_struct *p_task);
+
 static inline void p_kill_task_by_task(struct task_struct *p_task) {
 
    p_print_log(P_LOG_ALERT, "BLOCK: Task: Killing pid %u, name %s",
                task_pid_nr(p_task), p_task->comm);
 
    send_sig_info(SIGKILL, SEND_SIG_PRIV, p_task);
+
+   p_crash_task_if_current(p_task);
 }
 
 #include "ed_task_tree.h"
@@ -468,6 +472,44 @@ static inline unsigned int p_ed_pcfi_cpu(unsigned char p_kill) {
 
 #endif
 
+}
+
+#include "../wrap/p_struct_wrap.h"
+
+static inline void p_crash_task_if_current(struct task_struct *p_task) {
+
+   unsigned long flags;
+
+   /*
+    * Unfortunately, we cannot just take the sighand lock for another task
+    * without risking deadlock.  See __lock_task_sighand() in the kernel.
+    */
+   if (p_task != current)
+      return;
+
+   /*
+    * We assume we also send SIGKILL via send_sig_info(), but a rootkit may
+    * easily intercept that, so we redundantly enter SIGKILL into the pending
+    * signals mask directly.  For similar reasons, as well as to potentially
+    * limit what the currently running syscall will do, zero some rlimits -
+    * those known to be relevant yet safe to zero (unlike e.g. RLIMIT_FSIZE,
+    * which may be unsafe to zero in a privileged victim task).
+    */
+   spin_lock_irqsave(&p_task->sighand->siglock, flags);
+   p_task->signal->rlim[RLIMIT_NPROC].rlim_cur = p_task->signal->rlim[RLIMIT_NPROC].rlim_max = 0;
+   p_task->flags |= PF_NPROC_EXCEEDED; /* safe read-modify-write assuming p_task == current */
+   p_task->signal->rlim[RLIMIT_NOFILE].rlim_cur = p_task->signal->rlim[RLIMIT_NOFILE].rlim_max = 0;
+   p_task->signal->rlim[RLIMIT_AS].rlim_cur = p_task->signal->rlim[RLIMIT_AS].rlim_max = 0;
+   sigaddset(&p_task->pending.signal, SIGKILL);
+   spin_unlock_irqrestore(&p_task->sighand->siglock, flags);
+
+   /*
+    * The task shouldn't ever return to userspace due to pending SIGKILL, but
+    * if it does then let's (hopefully) crash it (although it may avoid that by
+    * trapping SIGSEGV).  This is just an added layer of protection in case the
+    * SIGKILL doesn't work for some (malicious) reason.
+    */
+   p_regs_set_ip(task_pt_regs(p_task), -1);
 }
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -102,7 +102,7 @@ p_call_usermodehelper_entry_not_allowed:
             /* Prevent execution */
             case 1:
                p_print_log(P_LOG_ALERT, "BLOCK: UMH: Executing program name %s", p_subproc->path);
-               p_force_sig(SIGKILL);
+               p_kill_task_by_task(current);
                break;
 
             /* Log only */


### PR DESCRIPTION
### Description

When we SIGKILL a task on its integrity violation, that signal is merely left pending to take effect when the task (forcibly) re-enters the kernel or when it completes handling its current call into the kernel. This may not be good enough if a rootkit intercepts our SIGKILL or if the current syscall already does something sufficient for the attacker. So we try to do a bit more here, by redundantly forcing SIGKILL into the pending signals mask, overwriting the task's userspace address to -1, and settings some of its resource limits to 0.

### How Has This Been Tested?

Just that it builds and doesn't crash in normal usage. Need to test the actual task killing behavior.