### PR TITLE
Fix possible seccomp deadlock when a thread's off flag is corrupted

### DIFF
--- a/src/modules/exploit_detection/ed_task_tree.h
+++ b/src/modules/exploit_detection/ed_task_tree.h
@@ -12,6 +12,7 @@ struct p_ed_process {
 	struct p_ed_process_task p_ed_task;
 	struct rcu_head rcu;
 	unsigned long kill_task_on_unlock;
+	struct p_ed_process *defer_kill_next;
 };
 
 extern unsigned long cookie_kill_task_on_unlock;
@@ -68,8 +69,19 @@ ed_task_find_lock_rcu(const struct task_struct *tsk)
 	return edp;
 }
 
-/* Unlock the ed task struct and kill the task if requested */
-static inline void ed_task_unlock(struct p_ed_process *edp)
+/*
+ * Unlock the ed task. Kill the task if requested, unless deferral of the task's
+ * killing is requested by providing a non-NULL @kill_list. Deferred kills are
+ * instead placed onto the provided singly-linked list. Deferral is needed when
+ * it's possible for an ed task to be killed underneath the sighand lock, which
+ * would otherwise deadlock because killing a task requires taking the sighand
+ * lock. Deferred kills must be processed by calling ed_task_kill_deferred().
+ *
+ * The RCU read lock held when looking up the kill-deferred ed task must remain
+ * held until after the complementary call to ed_task_kill_deferred().
+ */
+static inline void ed_task_unlock_defer_kill(struct p_ed_process *edp,
+					     struct p_ed_process **kill_list)
 {
 	struct task_struct *task_to_kill = NULL;
 
@@ -78,13 +90,41 @@ static inline void ed_task_unlock(struct p_ed_process *edp)
 		task_to_kill = edp->p_ed_task.p_task;
 	raw_spin_unlock(&edp->lock);
 
+	if (!task_to_kill)
+		return;
+
+	/* Append the task to a deferred kill list if deferral is requested */
+	if (kill_list) {
+		edp->defer_kill_next = *kill_list;
+		*kill_list = edp;
+		return;
+	}
+
 	/*
 	 * Kill the task outside of the ed task lock to avoid acquiring the
 	 * sighand lock underneath the ed task lock. This is needed to make it
 	 * safe to nest the ed task lock under the sighand lock.
 	 */
-	if (task_to_kill)
-		p_kill_task_by_task(task_to_kill);
+	p_kill_task_by_task(task_to_kill);
+}
+
+/* Unlock the ed task struct and kill the task if requested */
+static inline void ed_task_unlock(struct p_ed_process *edp)
+{
+	ed_task_unlock_defer_kill(edp, NULL);
+}
+
+/*
+ * Kill the list of ed tasks whose killing was deferred. The RCU read lock held
+ * when looking up the kill-deferred ed task must remain held until after this
+ * function finishes killing every ed task on the list.
+ */
+static inline void ed_task_kill_deferred(struct p_ed_process *kill_list)
+{
+	struct p_ed_process *edp;
+
+	for (edp = kill_list; edp; edp = edp->defer_kill_next)
+		p_kill_task_by_task(edp->p_ed_task.p_task);
 }
 
 #endif /* _LKRG_ED_TASK_TREE_H_ */

--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
@@ -25,7 +25,7 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 static __always_inline void p_seccomp_filter_tsync(bool entry) {
 
-   struct p_ed_process *p_tmp;
+   struct p_ed_process *kill_list = NULL, *p_tmp;
    struct task_struct *thread;
    unsigned long flags;
 
@@ -48,8 +48,9 @@ static __always_inline void p_seccomp_filter_tsync(bool entry) {
    /*
     * An RCU read lock is needed for all dereferences into another task's ed
     * struct in order to prevent it from getting freed while it's used, as the
-    * sighand lock alone doesn't keep ed structs pinned in memory. Just take the
-    * RCU read lock once for the entire loop for simplicity.
+    * sighand lock alone doesn't keep ed structs pinned in memory. Take the RCU
+    * read lock once for the entire loop because it needs to be held until after
+    * the sighand lock is released, in case there are tasks to kill.
     */
    rcu_read_lock();
    for_each_thread(current, thread) {
@@ -67,11 +68,19 @@ static __always_inline void p_seccomp_filter_tsync(bool entry) {
             }
             p_tmp->p_ed_task.p_sec.flag_sync_thread--;
          }
-         ed_task_unlock(p_tmp);
+         /*
+          * If the off flag was corrupted, then ed_task_unlock() will kill the
+          * task. Calling send_sig_info() would deadlock here though, because it
+          * needs the sighand lock which we're currently holding. Hence, defer
+          * any killing until after we've released the sighand lock.
+          */
+         ed_task_unlock_defer_kill(p_tmp, &kill_list);
       }
    }
-   rcu_read_unlock();
    spin_unlock_irqrestore(&current->sighand->siglock, flags);
+   /* Process any kills that were deferred now that the sighand lock is free */
+   ed_task_kill_deferred(kill_list);
+   rcu_read_unlock();
 }
 #endif
 


### PR DESCRIPTION
### Description
Depends on #467. Fixes #466.

### How Has This Been Tested?
Tested artificially using the following diff: 
<details><summary><b>Click to show artificial reproducer diff</b></summary>

```diff
diff --git a/src/modules/exploit_detection/ed_task_tree.h b/src/modules/exploit_detection/ed_task_tree.h
--- a/src/modules/exploit_detection/ed_task_tree.h
+++ b/src/modules/exploit_detection/ed_task_tree.h
@@ -95,6 +95,7 @@ static inline void ed_task_unlock_defer_kill(struct p_ed_process *edp,
 
 	/* Append the task to a deferred kill list if deferral is requested */
 	if (kill_list) {
+		printk("%s: deferring kill for task struct 0x%lx\n", __func__, (long)task_to_kill);
 		edp->defer_kill_next = *kill_list;
 		*kill_list = edp;
 		return;
@@ -123,8 +124,10 @@ static inline void ed_task_kill_deferred(struct p_ed_process *kill_list)
 {
 	struct p_ed_process *edp;
 
-	for (edp = kill_list; edp; edp = edp->defer_kill_next)
+	for (edp = kill_list; edp; edp = edp->defer_kill_next) {
+		printk("%s: executing deferred kill for task struct 0x%lx\n", __func__, (long)edp->p_ed_task.p_task);
 		p_kill_task_by_task(edp->p_ed_task.p_task);
+	}
 }
 
 #endif /* _LKRG_ED_TASK_TREE_H_ */
diff --git a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
@@ -28,6 +28,7 @@ static __always_inline void p_seccomp_filter_tsync(bool entry) {
    struct p_ed_process *kill_list = NULL, *p_tmp;
    struct task_struct *thread;
    unsigned long flags;
+   int count = 0;
 
    /*
     * It's possible for there to be a race between an indirect seccomp filter
@@ -53,6 +54,10 @@ static __always_inline void p_seccomp_filter_tsync(bool entry) {
     * the sighand lock is released, in case there are tasks to kill.
     */
    rcu_read_lock();
+   for_each_thread(current, thread) {
+      if (__ed_task_find_rcu(thread))
+         count++;
+   }
    for_each_thread(current, thread) {
       p_tmp = ed_task_find_lock_rcu(thread);
       if (p_tmp) {
@@ -68,6 +73,8 @@ static __always_inline void p_seccomp_filter_tsync(bool entry) {
             }
             p_tmp->p_ed_task.p_sec.flag_sync_thread--;
          }
+         if (count > 1) //XXX: test killing more than one thread
+            p_tmp->kill_task_on_unlock = 0; // XXX: trigger killing artificially
          /*
           * If the off flag was corrupted, then ed_task_unlock() will kill the
           * task. Calling sig_send_info() would deadlock here though, because it
```
</details>

Test log output after launching Firefox:
<details><summary><b>Click to show test log output</b></summary>

```
[   74.154568] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd083632340
[   74.154569] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd083632340
[   74.154570] LKRG: ALERT: BLOCK: Task: Killing pid 4014, name Utility Process
[   74.154574] LKRG: ALERT: BLOCK: Task: Killing pid 4014, name Utility Process
[   74.197394] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd083634680
[   74.197402] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd005730000
[   74.197403] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd005732340
[   74.197404] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd002618000
[   74.197405] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd05f720000
[   74.197405] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd0043d2340
[   74.197406] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd0043d4680
[   74.197406] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd0043d0000
[   74.197407] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd018124680
[   74.197407] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd018120000
[   74.197408] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd0066a0000
[   74.197409] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd05f70c680
[   74.197409] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd00573a340
[   74.197410] ed_task_unlock_defer_kill: deferring kill for task struct 0xffff8dd00573c680
[   74.197410] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd00573c680
[   74.197411] LKRG: ALERT: BLOCK: Task: Killing pid 4040, name WebExtensions
[   74.197438] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd00573a340
[   74.197441] LKRG: ALERT: BLOCK: Task: Killing pid 4035, name Worker Launcher
[   74.197442] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd05f70c680
[   74.197443] LKRG: ALERT: BLOCK: Task: Killing pid 4033, name ImageIO
[   74.197444] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd0066a0000
[   74.197444] LKRG: ALERT: BLOCK: Task: Killing pid 4026, name RemVidChild
[   74.197445] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd018120000
[   74.197445] LKRG: ALERT: BLOCK: Task: Killing pid 4025, name Timer
[   74.197446] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd018124680
[   74.197446] LKRG: ALERT: BLOCK: Task: Killing pid 4024, name Backgro~Pool #1
[   74.197446] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd0043d0000
[   74.197447] LKRG: ALERT: BLOCK: Task: Killing pid 4023, name JS Watchdog
[   74.197447] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd0043d4680
[   74.197448] LKRG: ALERT: BLOCK: Task: Killing pid 4022, name StyleThread#2
[   74.197449] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd0043d2340
[   74.197449] LKRG: ALERT: BLOCK: Task: Killing pid 4021, name StyleThread#1
[   74.197450] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd05f720000
[   74.197450] LKRG: ALERT: BLOCK: Task: Killing pid 4020, name HTML5 Parser
[   74.197450] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd002618000
[   74.197451] LKRG: ALERT: BLOCK: Task: Killing pid 4019, name Socket Thread
[   74.197451] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd005732340
[   74.197451] LKRG: ALERT: BLOCK: Task: Killing pid 4017, name IPC I/O Child
[   74.197453] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd005730000
[   74.197453] LKRG: ALERT: BLOCK: Task: Killing pid 4016, name MainThread
[   74.197454] ed_task_kill_deferred: executing deferred kill for task struct 0xffff8dd083634680
[   74.197454] LKRG: ALERT: BLOCK: Task: Killing pid 4009, name WebExtensions
```
</details>

Testing the artificial reproducer *without* this fix just immediately locks up my test VM, thus the fix works.