### PR TITLE
Fix possible livelock when freezing userspace at init

### DIFF
--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -424,6 +424,65 @@ static void p_parse_module_params(void) {
 
 }
 
+static void __init p_freeze_userspace(void) {
+
+   unsigned int timeout, tries, orig_timeout, sleep_ms;
+
+   /* Save the original freeze timeout that may have been set by the user */
+   orig_timeout = *P_SYM(p_freeze_timeout_msecs);
+
+   /* Start with a freeze timeout of 500 ms and a sleep duration of 50 ms */
+   timeout = min(500, orig_timeout);
+   sleep_ms = 50;
+
+   /*
+    * Freeze all user tasks with incremental timeouts and sleeps in between. The
+    * reason for starting with a shorter timeout is that a task blocking the
+    * freeze may depend on work from an already-frozen task in order to become
+    * unblocked. In this case, the freeze attempt will always continue until the
+    * timeout is reached, resulting in a long stall where most of userspace is
+    * frozen. The blocking task will always be running somewhere in the kernel,
+    * which is why it is blocking in the first place: it can't just teleport
+    * into the refrigerator when it's already stuck in some other kernel code.
+    *
+    * Some systems may legitimately require more time in order to freeze all
+    * user tasks, which is accommodated by incrementally scaling up the timeout
+    * duration.
+    *
+    * After a failed freeze attempt, we must wait a little bit to allow the
+    * blocking tasks to hopefully make enough forward progress to become
+    * unblocked. There's no precise way to track this, as the freezer is
+    * completely unaware of inter-process dependencies that must be satisfied to
+    * unblock a task.
+    */
+   *P_SYM(p_freeze_timeout_msecs) = timeout;
+   for (tries = 1; P_SYM_CALL(p_freeze_processes); tries++) {
+      /* Scale up after every 3 failed attempts */
+      if (!(tries % 3)) {
+         /* Don't sleep longer than 500 ms at a time (it probably won't help) */
+         sleep_ms = min(sleep_ms + 50, 500);
+
+         /* Increase the timeout, capping it to the original timeout duration */
+         timeout = min(timeout * 2, orig_timeout);
+         *P_SYM(p_freeze_timeout_msecs) = timeout;
+      }
+
+      p_print_log(P_LOG_ISSUE, "Freezing failed %u time(s), sleeping %u ms before next try with timeout of %u ms",
+                  tries, sleep_ms, timeout);
+
+      /* Sleep for a bit to give blocking tasks some time to become unblocked */
+      msleep(sleep_ms);
+   }
+
+   /*
+    * Restore the original freeze timeout. We may overwrite a userspace change
+    * to the freeze timeout via /sys/power/pm_freeze_timeout if the change
+    * occurred between when we cached the original timeout and now. This
+    * shouldn't be a big deal.
+    */
+   *P_SYM(p_freeze_timeout_msecs) = orig_timeout;
+}
+
 /*
  * Main entry point for the module - initialization.
  */
@@ -484,6 +543,7 @@ static int __init p_lkrg_register(void) {
       return P_LKRG_GENERAL_ERROR;
    }
 
+   P_SYM_INIT(freeze_timeout_msecs)
    P_SYM_INIT(freeze_processes)
    P_SYM_INIT(thaw_processes)
 #if defined(CONFIG_X86) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
@@ -498,8 +558,7 @@ static int __init p_lkrg_register(void) {
 #endif
 
    // Freeze all non-kernel processes
-   while (P_SYM_CALL(p_freeze_processes))
-      schedule();
+   p_freeze_userspace();
 
    p_freeze = 1;
 

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -190,6 +190,7 @@ typedef struct _p_lkrg_global_conf_structure {
 typedef struct _p_lkrg_global_symbols_structure {
 
    unsigned long (*p_kallsyms_lookup_name)(const char *name);
+   unsigned int *p_freeze_timeout_msecs;
    int (*p_freeze_processes)(void);
    void (*p_thaw_processes)(void);
 #if !defined(CONFIG_ARM64)


### PR DESCRIPTION
### How Has This Been Tested?
Tested with an artificially low freeze timeout of 1 ms at the beginning to verify the incremental scaling logic works:
```
[  940.161989] LKRG: ALIVE: Loading LKRG
[  940.173822] LKRG: ISSUE: Freezing failed 1 times, sleeping 50 ms before next try with timeout of 500 ms
[  940.310341] LKRG: ISSUE: Freezing failed 2 times, sleeping 50 ms before next try with timeout of 500 ms
[  940.370613] LKRG: ISSUE: Freezing failed 3 times, sleeping 100 ms before next try with timeout of 1000 ms
[  940.508990] LKRG: ISSUE: register_k[ret]probe() for ovl_dentry_is_whiteout failed! [err=-2]
[  940.508995] LKRG: ISSUE: Can't hook 'ovl_dentry_is_whiteout'. This is expected when OverlayFS is not used.
[  940.532609] LKRG: ISSUE: IOMMU table can't be found (skipping)
[  940.552855] LKRG: ALIVE: LKRG initialized successfully
[ 1037.567140] LKRG: DYING: Unloading LKRG
[ 1038.024993] LKRG: DYING: LKRG unloaded
[ 1039.047348] LKRG: ALIVE: Loading LKRG
[ 1039.057949] LKRG: ISSUE: Freezing failed 1 time(s), sleeping 50 ms before next try with timeout of 500 ms
[ 1039.178002] LKRG: ISSUE: Freezing failed 2 time(s), sleeping 50 ms before next try with timeout of 500 ms
[ 1039.238411] LKRG: ISSUE: Freezing failed 3 time(s), sleeping 100 ms before next try with timeout of 1000 ms
[ 1039.373313] LKRG: ISSUE: register_k[ret]probe() for ovl_dentry_is_whiteout failed! [err=-2]
[ 1039.373320] LKRG: ISSUE: Can't hook 'ovl_dentry_is_whiteout'. This is expected when OverlayFS is not used.
[ 1039.397475] LKRG: ISSUE: IOMMU table can't be found (skipping)
[ 1039.419382] LKRG: ALIVE: LKRG initialized successfully
```