### PR TITLE
Fix build for Linux 7.2+

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -449,8 +449,12 @@ void p_update_ed_process(struct p_ed_process *p_source, char p_stack) {
    p_dump_addr_limit(&p_source->p_ed_task.p_addr_limit, p_task);
 #endif
    /* Name */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7,2,0)
    strncpy(p_source->p_ed_task.p_comm, p_task->comm, TASK_COMM_LEN);
    p_source->p_ed_task.p_comm[TASK_COMM_LEN] = 0;
+#else
+   strscpy(p_source->p_ed_task.p_comm, p_task->comm, TASK_COMM_LEN + 1);
+#endif
    rcu_read_unlock();
 }
 


### PR DESCRIPTION
Linux Kernel 7.2 has removed `strncpy`, so it cannot be used.