### PR TITLE
Use `memcpy()` instead of `str(ns)cpy()`

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -449,12 +449,8 @@ void p_update_ed_process(struct p_ed_process *p_source, char p_stack) {
    p_dump_addr_limit(&p_source->p_ed_task.p_addr_limit, p_task);
 #endif
    /* Name */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(7,2,0)
-   strncpy(p_source->p_ed_task.p_comm, p_task->comm, TASK_COMM_LEN);
-   p_source->p_ed_task.p_comm[TASK_COMM_LEN] = 0;
-#else
-   strscpy(p_source->p_ed_task.p_comm, p_task->comm, TASK_COMM_LEN + 1);
-#endif
+   memcpy(p_source->p_ed_task.p_comm, p_task->comm, TASK_COMM_LEN);
+   p_source->p_ed_task.p_comm[TASK_COMM_LEN - 1] = 0;
    rcu_read_unlock();
 }
 

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -231,7 +231,7 @@ struct p_ed_process_task {
    unsigned long p_off;
    struct task_struct *p_task;
    pid_t p_pid;
-   char p_comm[TASK_COMM_LEN+1];
+   char p_comm[TASK_COMM_LEN];
    const struct cred *p_real_cred_ptr;
    struct p_cred p_real_cred;
 #if defined(CONFIG_SECCOMP)


### PR DESCRIPTION
As Solar Designer mentioned, it's better to use `memcpy()` here instead of `str(ns)cpy()`.